### PR TITLE
Finish defining conformance tests grammar for model-value

### DIFF
--- a/conformance/README.md
+++ b/conformance/README.md
@@ -561,9 +561,9 @@ type.
 These rules describe the overall shape of test cases:
 
 ```ebnf
-test ::=  "("  "ion_1_0"  name-string  fragment*  continuation  ")"
-       |  "("  "ion_1_1"  name-string  fragment*  continuation  ")"
-       |  "("  "ion_1_x"  name-string  fragment*  continuation  ")"
+test ::=  "("  "ion_1_0"  name-string?  fragment*  continuation  ")"
+       |  "("  "ion_1_1"  name-string?  fragment*  continuation  ")"
+       |  "("  "ion_1_x"  name-string?  fragment*  continuation  ")"
 
 name-string ::= string
 
@@ -619,7 +619,7 @@ model-content   ::=  null.null
                   |  "("  "null"      model-type       ")"
                   |  "("  "bool"      bool             ")"
                   |  "("  "int"       int              ")"
-                  |  "("  "float"     string           ")" // See https://amazon-ion.github.io/ion-docs/docs/float.html
+                  |  "("  "float"     model-float      ")"
                   |  "("  "decimal"   model-decimal    ")"
                   |  "("  "timestamp" model-timestamp  ")"
                   |  "("  "string"    codepoint*       ")"
@@ -639,27 +639,23 @@ model-symtok    ::=  string
 
 model-field     ::=  "("  model-symtok  model-value  ")"
 
+// TODO: Determine whether we can come up with anything better for model-float
+model-float     ::= string                                 // See https://amazon-ion.github.io/ion-docs/docs/float.html
+
 model-decimal   ::= int int                                // coefficient + exponent
-                  | "(" "negative_0" ")" int
+                  | "negative_0" int                       // negative zero coefficient + exponent
 
 // All timestamp subfields are interpreted as UTC time.
 // I.e. the following timestamps are not equivalent, but they represent the same point in time.
 // (timestamp (precision second) 1 2 3 (offset -1440) 4 5 6)
 // (timestamp (precision second) 1 2 3 (offset +1440) 4 5 6)
 
-model-timestamp ::= prec-year     int
-                  | prec-month    int int
-                  | prec-day      int int int
-                  | prec-minute   int int int offset int int
-                  | prec-second   int int int offset int int int
-                  | prec-fraction int int int offset int int int model-decimal
-
-prec-year       ::= "("  "precision"  "year"   ")"
-prec-month      ::= "("  "precision"  "month"  ")"
-prec-day        ::= "("  "precision"  "day"    ")"
-prec-minute     ::= "("  "precision"  "minute" ")"
-prec-second     ::= "("  "precision"  "second" ")"
-prec-fraction   ::= "("  "precision"  int      ")"         // positive, count of digits of fractional part of seconds
+model-timestamp ::= year     int
+                  | month    int int
+                  | day      int int int
+                  | minute   int int int offset int int
+                  | second   int int int offset int int int
+                  | fraction int int int offset int int int model-decimal
 
 offset          ::= "(" "offset" offset-minutes ")"
 

--- a/conformance/README.md
+++ b/conformance/README.md
@@ -647,8 +647,8 @@ model-decimal   ::= int int                                // coefficient + expo
 
 // All timestamp subfields are interpreted as UTC time.
 // I.e. the following timestamps are not equivalent, but they represent the same point in time.
-// (timestamp (precision second) 1 2 3 (offset -1440) 4 5 6)
-// (timestamp (precision second) 1 2 3 (offset +1440) 4 5 6)
+// (timestamp second 1 2 3 (offset -1440) 4 5 6)
+// (timestamp second 1 2 3 (offset +1440) 4 5 6)
 
 model-timestamp ::= year     int
                   | month    int int

--- a/conformance/README.md
+++ b/conformance/README.md
@@ -608,33 +608,51 @@ expectation, ending that branch of the test tree.
 These rules describe Ion data-model results for use in the `denotes` expectation:
 
 ```ebnf
-model-value   ::=  model-content  |  annotated
+model-value     ::=  model-content  |  annotated
 
-model-content ::=  null.null
-                |  bool
-                |  int
-                |  string
-                |  "("  "null"    model-type    ")"
-                |  "("  "string"  codepoint*    ")"
-                |  "("  "symbol"  model-symtok  ")"
-                |  "("  "list"    model-value*  ")"
-                |  "("  "sexp"    model-value*  ")"
-                |  "("  "struct"  model-field*  ")"
-                |  "("  "blob"    bytes*        ")"
-                |  "("  "clob"    bytes*        ")"
+model-content   ::=  null.null
+                  |  bool
+                  |  int
+                  |  string
+                  |  "("  "null"      model-type       ")"
+                  |  "("  "bool"      bool             ")"
+                  |  "("  "int"       int              ")"
+                  |  "("  "float"     string           ")" // See https://amazon-ion.github.io/ion-docs/docs/float.html
+                  |  "("  "decimal"   model-decimal    ")"
+                  |  "("  "timestamp" model-timestamp  ")"
+                  |  "("  "string"    codepoint*       ")"
+                  |  "("  "symbol"    model-symtok     ")"
+                  |  "("  "list"      model-value*     ")"
+                  |  "("  "sexp"      model-value*     ")"
+                  |  "("  "struct"    model-field*     ")"
+                  |  "("  "blob"      bytes*           ")"
+                  |  "("  "clob"      bytes*           ")"
 
 // TODO Other types per denotational semantics
 
-codepoint     ::=  int                               // in the range 0..0x10FFFF
+codepoint       ::=  int                                   // in the range 0..0x10FFFF
 
-model-symtok  ::=  string
-                |  int
-                |  "("  "text"  codepoint*  ")"
-                |  "("  "absent"  string  int  ")"       // symtab name + offset
+model-symtok    ::=  string
+                  |  int
+                  |  "("  "text"  codepoint*  ")"
+                  |  "("  "absent"  string  int  ")"       // symtab name + offset
 
-model-field   ::=  "("  model-symtok  model-value  ")"
+model-field     ::=  "("  model-symtok  model-value  ")"
 
-annotated     ::=  "("  "annot"  model-content  string*  ")"
+model-decimal   ::= int int                                // coefficient + exponent
+                  | "negative_zero" int
+
+model-timestamp ::= int
+                  | int int
+                  | int int int
+                  | int int int int int offset?
+                  | int int int int int int offset?
+                  | int int int int int decimal offset?
+
+offset          ::= "Z"
+                  | string                                 // content matches ^[+-]\d{2}:\d{2}$
+
+annotated       ::=  "("  "annot"  model-content  model-symtok*  ")"
 ```
 
 The `model-content` forms `(string ...)` and `(symbol (text ...))` express text


### PR DESCRIPTION
**Issue #, if available:**

None

**Description of changes:**

Most things are straightforward, here are a few things of note.
* I've used `negative_zero` to represent `-0`. The problem I'm trying to avoid is relying on whitespace to differentiate between e.g. `(decimal - 0 1)` vs `(decimal -0 1)`. Since Ion doesn't differentiate between positive and negative zero integers, the second example is equivalent to `(decimal 0 1)`.
* I included `bool` and `int` in the model DSL for completeness. They are redundant, though.
* I believe that `annot` should probably use `model-symtok` for the annotations, not just `string`.
* `model-timestamp` depends on `decimal`. This simplifies the DSL compared to having `model-decimal` or `int int` for the fractional part, but it also requires that the implementation can read text decimals before the `model-timestamp` can be parsed correctly. However, I think that is probably okay because the fractional seconds parser implementations have some in common with the decimal parsers, and practically speaking, decimals have almost always been implemented before timestamps.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
