### PR TITLE
Add basic conformance tests for IVMs, system symbols, and local symtabs.

### DIFF
--- a/conformance/ivm.ion
+++ b/conformance/ivm.ion
@@ -1,0 +1,11 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+(ion_1_x
+  // IVMs don't appear in output data.
+  (toplevel '#$ion_1_0' null '#$ion_1_1' null)
+  (produces null null))
+
+(ion_1_x
+  (toplevel null '#$ion_12_34')
+  (signals "Unsupported Ion version: 12.34"))

--- a/conformance/local_symtab.ion
+++ b/conformance/local_symtab.ion
@@ -21,7 +21,7 @@
 // Basic symbol expansion
 (ion_1_0
   (each (toplevel $ion_symbol_table::{symbols:["a"]})
-        (toplevel                $3::{     $7:["a"]})
+        (toplevel             '#$3'::{  '#$7':["a"]})
         (then (toplevel '#$10'::'#$10' '#$10')
               (produces      a::a         a))))
 

--- a/conformance/local_symtab.ion
+++ b/conformance/local_symtab.ion
@@ -1,0 +1,71 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+
+// Non-structs pass through
+(ion_1_x
+  (then (toplevel first $ion_symbol_table::[] second)
+        (produces first $ion_symbol_table::[] second))
+  (then (toplevel first $ion_symbol_table::() second)
+        (produces first $ion_symbol_table::() second)))
+
+// IST structs are elided from app view
+(ion_1_x
+  (then (toplevel first $ion_symbol_table::{} $ion_symbol_table::null.struct second)
+        (produces first                                                      second))
+  // ...but only at top-level
+  (then (toplevel [first, $ion_symbol_table::{}, $ion_symbol_table::null.struct, second])
+        (produces [first, $ion_symbol_table::{}, $ion_symbol_table::null.struct, second])))
+
+
+// Basic symbol expansion
+(ion_1_0 (toplevel $ion_symbol_table::{symbols:["a"]})
+         (toplevel '#$10'::'#$10' '#$10')
+         (produces      a::a         a))
+
+
+// Out-of-bounds SID
+//  At present, the DSL doesn't support partial expansion of the front of stream.
+(ion_1_0
+  (then (toplevel '#$10')
+        (signals "Invalid symbol address: 10"))
+  (then (toplevel $ion_symbol_table::{symbols:["a"]})
+        (then (toplevel '#$11')
+              (signals "Invalid symbol address: 11")))
+  (then (toplevel $ion_symbol_table::{symbols:["a", "b"]})
+        (then (toplevel '#$10' '#$11')
+              (produces a b))
+        (then (toplevel '#$12')
+              (signals "Invalid symbol address: 12"))))
+
+
+// Empty, null, or malformed `symbols` field is ignored
+(ion_1_0 (each (toplevel $ion_symbol_table::{symbols:[]       })
+               (toplevel $ion_symbol_table::{symbols:null.list})
+               (toplevel $ion_symbol_table::{symbols:42       })
+               (toplevel $ion_symbol_table::{symbols:("b")    })
+               (then (toplevel '#$10')
+                     (signals "Invalid symbol address: 10"))))
+
+
+// Non-string and null (local) `symbols` entries act like $0
+(ion_1_0
+  (then (toplevel $ion_symbol_table::{symbols:[a, 1, true, ()]}
+                  '#$10' '#$11' '#$12' '#$13')
+        (produces '#$0'  '#$0'  '#$0'  '#$0'))
+  (then (toplevel $ion_symbol_table::{symbols:["a", null.null, null.symbol, null.string, null.int, "b"]})
+        (toplevel '#$10' '#$11' '#$12' '#$13' '#$14' '#$15')
+        (produces a      '#$0'  '#$0'  '#$0'  '#$0'  b)))
+
+// Successive ISTs replace earlier ones
+(ion_1_0 (toplevel $ion_symbol_table::{symbols:["a"]} '#$10'
+                   $ion_symbol_table::{symbols:["b"]} '#$10')
+         (produces a b))
+
+// $ion_symbol_table must be first annotation
+(ion_1_0
+  (then (toplevel not::$ion_symbol_table::{symbols:["a"]})
+        (produces not::$ion_symbol_table::{symbols:["a"]}))
+  (then (toplevel $ion_symbol_table::{symbols:["a"]}
+                  '#$10' not::$ion_symbol_table::{symbols:["b"]} '#$10')
+        (produces a      not::$ion_symbol_table::{symbols:["b"]} a)))

--- a/conformance/local_symtab.ion
+++ b/conformance/local_symtab.ion
@@ -19,9 +19,11 @@
 
 
 // Basic symbol expansion
-(ion_1_0 (toplevel $ion_symbol_table::{symbols:["a"]})
-         (toplevel '#$10'::'#$10' '#$10')
-         (produces      a::a         a))
+(ion_1_0
+  (each (toplevel $ion_symbol_table::{symbols:["a"]})
+        (toplevel                $3::{     $7:["a"]})
+        (then (toplevel '#$10'::'#$10' '#$10')
+              (produces      a::a         a))))
 
 
 // Out-of-bounds SID

--- a/conformance/system_symbols.ion
+++ b/conformance/system_symbols.ion
@@ -1,0 +1,18 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+(ion_1_x
+  (toplevel '#$1' '#$2' '#$3' '#$4' '#$5' '#$6' '#$7' '#$8' '#$9')
+  (produces $ion $ion_1_0
+            $ion_symbol_table name version imports symbols max_id
+            $ion_shared_symbol_table))
+
+(ion_1_0
+  (toplevel '#$10')
+  (signals "Invalid symbol address: 10"))
+
+(ion_1_1
+  (toplevel '#$10')
+  (produces $ion_literal))
+
+// TODO Ion 1.1 system symtab upper-bound

--- a/conformance/system_symbols.ion
+++ b/conformance/system_symbols.ion
@@ -12,7 +12,7 @@
   (signals "Invalid symbol address: 10"))
 
 (ion_1_1
-  (toplevel '#$10')
-  (produces $ion_literal))
+  (toplevel '#$10'        '#$11')
+  (produces $ion_encoding $ion_literal))
 
 // TODO Ion 1.1 system symtab upper-bound


### PR DESCRIPTION
*Description of changes:*

I believe the only 1.1-specific impact here is the test asserting that $10 is `$ion_literal`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
