### PR TITLE
Add tests for trivial `$ion_encoding` forms.

### DIFF
--- a/conformance/ion_encoding/trivial_forms.ion
+++ b/conformance/ion_encoding/trivial_forms.ion
@@ -1,0 +1,26 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+
+// Non-sexps pass through
+(ion_1_x
+  (then (toplevel $ion_encoding::null)
+        (produces $ion_encoding::null))
+  (then (toplevel $ion_encoding::12)
+        (produces $ion_encoding::12))
+  (then (toplevel $ion_encoding::[])
+        (produces $ion_encoding::[]))
+  (then (toplevel $ion_encoding::{})
+        (produces $ion_encoding::{})))
+
+// Encoding directives are elided from app view
+(ion_1_1
+  (toplevel 1 $ion_encoding::() $ion_encoding::null.sexp 2)
+  (produces 1 2))
+
+// DSL-provided shorthand
+(ion_1_1
+  (toplevel 1)
+  (encoding)
+  (toplevel 2)
+  (produces 1 2))


### PR DESCRIPTION
Assumes support for the DSL's `encoding` clause.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
