### PR TITLE
Update `name-string` in `each` clauses

### DIFF
--- a/conformance/README.md
+++ b/conformance/README.md
@@ -631,7 +631,9 @@ expectation  ::=  "("  "produces"  datum*        ")"       // "datum" is any val
                |  "("  "not"       expectation   ")"
 
 extension    ::=  "("  "then"  name-string?  fragment*  continuation  ")"
-               |  "("  "each"  name-string?  fragment*  continuation  ")"
+               |  "("  "each"  each-branch*  continuation  ")"
+
+each-branch  ::=  name-string?  fragment
 
 bytes  ::=  int      // In the range 0..255
          |  string   // Containing hexadecimal digits and whitespace


### PR DESCRIPTION
**Issue #, if available:**

None

**Description of changes:**

This allows us to have different names for different branches created by an `each` clause.


_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
