### PR TITLE
Change 'binary'->'bytes' in IVM tests

### DIFF
--- a/conformance/ivm.ion
+++ b/conformance/ivm.ion
@@ -3,12 +3,12 @@
 
 (document "IVMs don't appear in output data"
   (each (text      "$ion_1_0")
-        (binary    "E0  01 00   EA")
+        (bytes    "E0  01 00   EA")
         (ivm             1 0)
         (toplevel '#$ion_1_0')
         (then (toplevel 1)
               (each (text      "$ion_1_0")
-                    (binary    "E0  01 00   EA")
+                    (bytes    "E0  01 00   EA")
                     (ivm             1 0)
                     (toplevel '#$ion_1_0')
                     (then (toplevel 2)
@@ -17,7 +17,7 @@
 
 (document "Invalid IVM version"
   (each (text      "$ion_12_34")
-        (binary    "E0   0C 22   EA")
+        (bytes    "E0   0C 22   EA")
         (ivm             12 34)
         (toplevel '#$ion_12_34')
         (signals "Unsupported Ion version: 12.34")))


### PR DESCRIPTION
**Issue #, if available:**

None

**Description of changes:**

Fixes a few tests that have "binary" instead of "bytes".

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
