### PR TITLE
Selects larger v1.1 symbol ID to be out of bounds

### DIFF
--- a/iontestdata_1_1/bad/annotationSymbolIDUnmapped.ion
+++ b/iontestdata_1_1/bad/annotationSymbolIDUnmapped.ion
@@ -1,3 +1,3 @@
 $ion_1_1
 // The annotation is out of range of the local symbol table.
-$10::0
+$100::0

--- a/iontestdata_1_1/bad/fieldNameSymbolIDUnmapped.ion
+++ b/iontestdata_1_1/bad/fieldNameSymbolIDUnmapped.ion
@@ -1,3 +1,3 @@
 $ion_1_1
 // The field name is out of range of the local symbol table.
-{$10: 0}
+{$100: 0}


### PR DESCRIPTION
There are two test files that currently reference `$10`, expecting it to be undefined. This is the case in Ion 1.0. However, at the start of an Ion v1.1 stream, symbol addresses up to 65 are valid, meaning that `$10` is legal.

This PR sets the `$10` in both files to `$100`, which is out of bounds at the head of the stream in both Ion versions.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
