### PR TITLE
Adds tests cases for make_* system macros

### DIFF
--- a/conformance/system_macros/make_decimal.ion
+++ b/conformance/system_macros/make_decimal.ion
@@ -1,9 +1,64 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-// Test Cases:
-// make_decimal can be invoked using any type of macro reference.
-// make_decimal creates a single unannotated decimal
-// the coefficient argument must be a non-null integer
-// the exponent argument must be a non-null integer
-// annotations on the argument values are silently dropped
+(ion_1_1 "make_decimal can be invoked"
+         (each "in text with an unqualified macro name"
+               (text " (:make_decimal 0 0) ")
+               "in text with an unqualified macro address"
+               (text " (:6 0 0) ")
+               "in text with a qualified macro name"
+               (text " (:$ion::make_decimal 0 0) ")
+               "in text using qualified system macro address 6"
+               (text " (:$ion::6 0 0) ")
+               "in binary using system macro address 6"
+               (binary "EF 06 01 01")
+               "in binary with a user macro address"
+               (binary "06 01 01")
+               (produces 0.)))
+
+(ion_1_1 "the first argument must be a single, non-null integer"
+         (each (text " (:make_decimal     null 0) ")
+               (text " (:make_decimal null.int 0) ")
+               (text " (:make_decimal      0e0 0) ")
+               (text " (:make_decimal      0d0 0) ")
+               (text " (:make_decimal  (:none) 0) ")
+               (text " (:make_decimal (:: 1 2) 0) ")
+               (signals "invalid argument")))
+
+(ion_1_1 "the second argument must be a single, non-null integer"
+         (each (text " (:make_decimal 0     null) ")
+               (text " (:make_decimal 0 null.int) ")
+               (text " (:make_decimal 0      0e0) ")
+               (text " (:make_decimal 0      0d0) ")
+               (text " (:make_decimal 0  (:none)) ")
+               (text " (:make_decimal 0 (:: 1 2)) ")
+               (signals "invalid argument")))
+
+(ion_1_1 "in binary both arguments are encoded as flex_int"
+         (then (binary "EF 06 01    01   ") (produces 0d0))
+         (then (binary "EF 06 03    03   ") (produces 1d1))
+         (then (binary "EF 06 06 00 06 00") (produces 1d1))
+         (then (binary "EF 06 9E F4 01   ") (produces -729d0))
+         (then (binary "EF 06 01    9E F4") (produces 0d-729))
+         (then (binary "EF 06 FF    FF   ") (produces -1d-1))
+         (then (binary "EF 06 FE FF FE FF") (produces -1d-1)))
+
+(ion_1_1 "make_decimal creates a single unannotated decimal"
+         (then (text "(:make_decimal -3 1)") (produces -3d1))
+         (then (text "(:make_decimal -2 1)") (produces -2d1))
+         (then (text "(:make_decimal -1 1)") (produces -1d1))
+         (then (text "(:make_decimal -0 1)") (produces  0d1))
+         (then (text "(:make_decimal  0 1)") (produces  0d1))
+         (then (text "(:make_decimal  1 1)") (produces  1d1))
+         (then (text "(:make_decimal  2 1)") (produces  2d1))
+         (then (text "(:make_decimal  3 1)") (produces  3d1))
+         (then (text "(:make_decimal 2 -3)") (produces 2d-3))
+         (then (text "(:make_decimal 2 -2)") (produces 2d-2))
+         (then (text "(:make_decimal 2 -1)") (produces 2d-1))
+         (then (text "(:make_decimal 2 -0)") (produces 2d0))
+         (then (text "(:make_decimal 2  0)") (produces 2d0))
+         (then (text "(:make_decimal 2  1)") (produces 2d1))
+         (then (text "(:make_decimal 2  2)") (produces 2d2))
+         (then (text "(:make_decimal 2  3)") (produces 2d3))
+         // Argument annotations are silently dropped.
+         (then (text "(:make_decimal a::3  b::3)") (produces 3d3)))

--- a/conformance/system_macros/make_field.ion
+++ b/conformance/system_macros/make_field.ion
@@ -1,10 +1,68 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-// Test Cases:
-// make_field can be invoked using any type of macro reference.
-// the first argument must expand to a single non-null text value (`$0` is allowed)
-// annotations first argument are silently dropped
-// the second argument may be any single expression that expands to a single expression
-// make_field expands to a single unannotated struct containing only field(s) with the first argument as the field name,
-//     and the second argument value as the field value.
+(ion_1_1 "make_field can be invoked"
+         (each "in text with an unqualified macro name"
+               (text " (:make_field foo 0) ")
+               "in text with an unqualified macro address"
+               (text " (:22 foo 0) ")
+               "in text with a qualified macro name"
+               (text " (:$ion::make_field foo 0) ")
+               "in text using qualified system macro address 22"
+               (text " (:$ion::22 foo 0) ")
+               "in binary using system macro address 22"
+               (binary "EF 16 FB 66 6F 6F 60")
+               "in binary with a user macro address"
+               (binary "16 FB 66 6F 6F 60")
+               (produces {foo: 0} )))
+
+(ion_1_1 "the first argument"
+         (then "can be"
+               (each "a string"
+                     (text ''' (:make_field "foo" 0) ''')
+                     "a symbol with known text"
+                     (text "(:make_field foo 0)")
+                     "an expression that produces text"
+                     (text "(:make_field (:values 'foo') 0)")
+                     "annotated"
+                     (text "(:make_field bar::foo 0)")
+                     (produces {foo:0} ))
+               (then "a symbol with unknown text"
+                     (text "(:make_field $0 1)")
+                     // Could be (produces {$0:1} ), but some implementations don't support $0 nicely.
+                     (denotes (Struct (0 1)))))
+         (then "cannot be"
+               (each "null"
+                     (text "(:make_field null 0)")
+                     "a null symbol"
+                     (text "(:make_field null.symbol 0)")
+                     "a null string"
+                     (text "(:make_field null.string 0)")
+                     "a non-text value"
+                     (text "(:make_field 123 0)")
+                     "empty expression group"
+                     (text "(:make_field (::) 0)")
+                     "nothing"
+                     (text "(:make_field (:none) 0)")
+                     (signals "invalid argument"))))
+
+(ion_1_1 "the second argument"
+         (then "can be"
+               (then "a single value"
+                     (text "(:make_field foo 0)")
+                     (produces {foo:0} ))
+               (then "an expression that produces a single value"
+                     (text "(:make_field foo (:values foo))")
+                     (produces {foo:0} )))
+         (then "cannot be"
+               (each "missing"
+                     (text "(:make_field foo)")
+                     "an empty expression group"
+                     (text "(:make_field foo (::))")
+                     "an expression that produces no values"
+                     (text "(:make_field foo (:none))")
+                     "an expression that produces multiple values"
+                     (text "(:make_field foo (:values 1 2 3))")
+                     "an expression group with multiple values"
+                     (text "(:make_field foo (:: 1 2 3))")
+                     (signals "invalid argument"))))

--- a/conformance/system_macros/make_list.ion
+++ b/conformance/system_macros/make_list.ion
@@ -1,8 +1,62 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-// Test Cases:
-// make_list can be invoked using any type of macro reference.
-// the argument values may be zero or more non-null lists and s-expressions
-// make_list creates a single unannotated list whose elements are the concatenated elements of all its arguments
-// annotations on the argument values are silently dropped
+(ion_1_1 "make_list can be invoked"
+         (each "in text with an unqualified macro name"
+               (text " (:make_list (::)) ")
+               "in text with an unqualified macro address"
+               (text " (:8 (::)) ")
+               "in text with a qualified macro name"
+               (text " (:$ion::make_list (::)) ")
+               "in text using qualified system macro address 8"
+               (text " (:$ion::8 (::)) ")
+               "in binary using system macro address 8"
+               (binary "EF 08 00")
+               "in binary with a user macro address"
+               (binary "08 00")
+               (produces [])))
+
+(ion_1_1 "make_list creates a single, unannotated list from"
+         (then "0 values"
+               (text "(:make_list)")
+               (produces []))
+         (each "one list"
+               (text "(:make_list [1, 2, 3])")
+               "multiple lists"
+               (text "(:make_list [1, 2] [3])")
+               (text "(:make_list [1] [2] [3])")
+               (text "(:make_list [] [1, 2, 3] [])")
+               (text "(:make_list [] [1] [] [2] [] [3] [])")
+               "one sexp"
+               (text "(:make_list (1 2 3))")
+               "multiple sexps"
+               (text "(:make_list (1 2) (3))")
+               (text "(:make_list (1) (2) (3))")
+               (text "(:make_list () (1 2 3) ())")
+               (text "(:make_list () (1) () (2) () (3) ())")
+               "a mix of lists and sexps"
+               (text "(:make_list () [1] (2) [3])")
+               (text "(:make_list (1) [2, 3] ())")
+               "annotated sequence values"
+               // Argument annotations are silently dropped.
+               (text "(:make_list a::() b::[1] c::(2) d::[3])")
+               (produces [1, 2, 3])))
+
+(ion_1_1 "the argument cannot be"
+         (each "null"
+               (text "(:make_list null)")
+               (text "(:make_list [1] null [2])")
+               "null.list"
+               (text "(:make_list null.list)")
+               (text "(:make_list [1] null.list [2])")
+               "null.sexp"
+               (text "(:make_list null.sexp)")
+               (text "(:make_list [1] null.sexp [2])")
+               "a non-sequence value"
+               (text "(:make_list {{ '''abc''' }})")
+               (text "(:make_list [1] {{ '''abc''' }} [2])")
+               (text "(:make_list 123)")
+               (text "(:make_list [1] 123 [2])")
+               (text "(:make_list { a: 1 })")
+               (text "(:make_list [1] { a: 1 } [2])")
+               (signals "invalid argument")))

--- a/conformance/system_macros/make_sexp.ion
+++ b/conformance/system_macros/make_sexp.ion
@@ -1,8 +1,62 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-// Test Cases:
-// make_sexp can be invoked using any type of macro reference.
-// the argument values may be zero or more non-null lists and s-expressions
-// make_sexp creates a single unannotated s-expression whose elements are the concatenated elements of all its arguments
-// annotations on the argument values are silently dropped
+(ion_1_1 "make_sexp can be invoked"
+         (each "in text with an unqualified macro name"
+               (text " (:make_sexp (::)) ")
+               "in text with an unqualified macro address"
+               (text " (:9 (::)) ")
+               "in text with a qualified macro name"
+               (text " (:$ion::make_sexp (::)) ")
+               "in text using qualified system macro address 9"
+               (text " (:$ion::9 (::)) ")
+               "in binary using system macro address 9"
+               (binary "EF 09 00")
+               "in binary with a user macro address"
+               (binary "09 00")
+               (produces ())))
+
+(ion_1_1 "make_sexp creates a single, unannotated sexp from"
+         (then "0 values"
+               (text "(:make_sexp)")
+               (produces ()))
+         (each "one list"
+               (text "(:make_sexp [1, 2, 3])")
+               "multiple lists"
+               (text "(:make_sexp [1, 2] [3])")
+               (text "(:make_sexp [1] [2] [3])")
+               (text "(:make_sexp [] [1, 2, 3] [])")
+               (text "(:make_sexp [] [1] [] [2] [] [3] [])")
+               "one sexp"
+               (text "(:make_sexp (1 2 3))")
+               "multiple sexps"
+               (text "(:make_sexp (1 2) (3))")
+               (text "(:make_sexp (1) (2) (3))")
+               (text "(:make_sexp () (1 2 3) ())")
+               (text "(:make_sexp () (1) () (2) () (3) ())")
+               "a mix of lists and sexps"
+               (text "(:make_sexp () [1] (2) [3])")
+               (text "(:make_sexp (1) [2, 3] ())")
+               "annotated sequence values"
+               // Argument annotations are silently dropped.
+               (text "(:make_sexp a::() b::[1] c::(2) d::[3])")
+               (produces (1 2 3))))
+
+(ion_1_1 "the argument cannot be"
+         (each "null"
+               (text "(:make_sexp null)")
+               (text "(:make_sexp (1) null (2))")
+               "null.list"
+               (text "(:make_sexp null.list)")
+               (text "(:make_sexp (1) null.list (2))")
+               "null.sexp"
+               (text "(:make_sexp null.sexp)")
+               (text "(:make_sexp (1) null.sexp (2))")
+               "a non-sequence value"
+               (text "(:make_sexp {{ '''abc''' }})")
+               (text "(:make_sexp (1) {{ '''abc''' }} (2))")
+               (text "(:make_sexp 123)")
+               (text "(:make_sexp (1) 123 (2))")
+               (text "(:make_sexp { a: 1 })")
+               (text "(:make_sexp (1) { a: 1 } (2))")
+               (signals "invalid argument")))

--- a/conformance/system_macros/make_string.ion
+++ b/conformance/system_macros/make_string.ion
@@ -1,8 +1,74 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-// Test Cases:
-// make_string can be invoked using any type of macro reference.
-// make_string creates a single unannotated string from zero or more text values
-// null values, unknown symbol text, and non-text values must signal an error
-// annotations on the argment values are silently dropped
+(ion_1_1 "make_string can be invoked"
+         (each "in text with an unqualified macro name"
+               (text " (:make_string (::)) ")
+               "in text with an unqualified macro address"
+               (text " (:3 (::)) ")
+               "in text with a qualified macro name"
+               (text " (:$ion::make_string (::)) ")
+               "in text using qualified system macro address 3"
+               (text " (:$ion::3 (::)) ")
+               "in binary using system macro address 3"
+               (binary "EF 03 00")
+               "in binary with a user macro address"
+               (binary "03 00")
+               (produces "")))
+
+(ion_1_1 "make_string creates a single, unannotated string from"
+         (then "0 values"
+               (text ''' (:make_string) ''')
+               (produces ""))
+         (then "1 string"
+               (text ''' (:make_string "a") ''')
+               (produces "a"))
+         (then "2 strings"
+               (text ''' (:make_string "a" "b") ''')
+               (produces "ab"))
+         (then "3 strings"
+               (text ''' (:make_string "a" "b" "c") ''')
+               (produces "abc"))
+         (then "1 symbol"
+               (text ''' (:make_string a) ''')
+               (produces "a"))
+         (then "2 symbols"
+               (text ''' (:make_string a b) ''')
+               (produces "ab"))
+         (then "3 symbols"
+               (text ''' (:make_string a b c) ''')
+               (produces "abc"))
+         (then "a mix of strings and symbols"
+               (text ''' (:make_string a "b" c "d") ''')
+               (produces "abcd"))
+         (then "an expression that produces multiple text values"
+               (text ''' (:make_string (:values a "b" c)) ''')
+               (produces "abc"))
+         (then "annotated text values"
+               // Argument annotations are silently dropped.
+               (text ''' (:make_string x::a y::"b" z::c) ''')
+               (produces "abc")))
+
+(ion_1_1 "the argument cannot be"
+         (each "null"
+               (text ''' (:make_string null) ''')
+               (text ''' (:make_string "a" null "b") ''')
+               "null.string"
+               (text ''' (:make_string null.string) ''')
+               (text ''' (:make_string "a" null.string "b") ''')
+               "null.symbol"
+               (text ''' (:make_string null.symbol) ''')
+               (text ''' (:make_string "a" null.symbol "b") ''')
+               "a non-text value"
+               (text ''' (:make_string {{ "abc" }}) ''')
+               (text ''' (:make_string 123) ''')
+               (text ''' (:make_string ["a", "b", "c"]) ''')
+               (text ''' (:make_string "a" {{ "abc" }} "b") ''')
+               (text ''' (:make_string "a" 123 "b") ''')
+               (text ''' (:make_string "a" ["a", "b", "c"] "b") ''')
+               "a symbol with unknown text"
+               (text ''' (:make_string $0) ''')
+               (text ''' (:make_string "a" $0 "b") ''')
+               (text ''' (:make_string $9999999) ''')
+               (text ''' (:make_string "a" $9999999 "b") ''')
+               (signals "invalid argument")))

--- a/conformance/system_macros/make_struct.ion
+++ b/conformance/system_macros/make_struct.ion
@@ -1,8 +1,55 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-// Test Cases:
-// make_struct can be invoked using any type of macro reference.
-// the argument values may be zero or more non-null structs
-// make_struct creates a single unannotated struct whose fields are the concatenated fields of all its arguments
-// annotations on the argument values are silently dropped
+(ion_1_1 "make_struct can be invoked"
+         (each "in text with an unqualified macro name"
+               (text " (:make_struct (::)) ")
+               "in text with an unqualified macro address"
+               (text " (:10 (::)) ")
+               "in text with a qualified macro name"
+               (text " (:$ion::make_struct (::)) ")
+               "in text using qualified system macro address 10"
+               (text " (:$ion::10 (::)) ")
+               "in binary using system macro address 10"
+               (binary "EF 0A 00")
+               "in binary with a user macro address"
+               (binary "0A 00")
+               (produces {})))
+
+(ion_1_1 "make_struct creates a single, unannotated struct from"
+         (then "0 values"
+               (text "(:make_struct)")
+               (produces {}))
+         (each "one struct"
+               (text "(:make_struct {a:1, b:2, c:3})")
+               "multiple structs"
+               (text "(:make_struct {a:1, b:2} {b:3})")
+               (text "(:make_struct [1] [2] {b:3})")
+               (text "(:make_struct {} [1, 2, 3] {})")
+               (text "(:make_struct {} [1] {} [2] {} {b:3} {})")
+               "annotated struct values"
+               // Argument annotations are silently dropped.
+               (text "(:make_struct a::{} b::{a:1} c::{b:2} d::{c:3})")
+               (produces {a:1, b:2, c:3}))
+         (then "structs with repeated fields"
+               (text "(:make_struct {a:1} {a:1})")
+               (produces {a:1, a:1}))
+         (then "structs with repeated field names"
+               (text "(:make_struct {a:2} {a:3})")
+               (produces {a:2, a:3})))
+
+(ion_1_1 "the argument cannot be"
+         (each "null"
+               (text "(:make_struct null)")
+               (text "(:make_struct {a:1} null {b:2})")
+               "null.struct"
+               (text "(:make_struct null.struct)")
+               (text "(:make_struct {a:1} null.struct {b:2})")
+               "a non-struct value"
+               (text "(:make_struct {{ '''abc''' }})")
+               (text "(:make_struct {a:1} {{ '''abc''' }} {b:2})")
+               (text "(:make_struct 123)")
+               (text "(:make_struct {a:1} 123) {b:2}")
+               (text "(:make_struct (a 1) )")
+               (text "(:make_struct {a:1} (a 1) ) {b:2}")
+               (signals "invalid argument")))

--- a/conformance/system_macros/make_struct.ion
+++ b/conformance/system_macros/make_struct.ion
@@ -17,16 +17,17 @@
                (produces {})))
 
 (ion_1_1 "make_struct creates a single, unannotated struct from"
-         (then "0 values"
+         (each "0 values"
                (text "(:make_struct)")
+               "empty structs"
+               (text "(:make_struct {})")
+               (text "(:make_struct {} {} {})")
                (produces {}))
          (each "one struct"
                (text "(:make_struct {a:1, b:2, c:3})")
                "multiple structs"
                (text "(:make_struct {a:1, b:2} {b:3})")
-               (text "(:make_struct [1] [2] {b:3})")
-               (text "(:make_struct {} [1, 2, 3] {})")
-               (text "(:make_struct {} [1] {} [2] {} {b:3} {})")
+               (text "(:make_struct {} {a:1} {} {b:2} {} {b:3})")
                "annotated struct values"
                // Argument annotations are silently dropped.
                (text "(:make_struct a::{} b::{a:1} c::{b:2} d::{c:3})")
@@ -49,7 +50,11 @@
                (text "(:make_struct {{ '''abc''' }})")
                (text "(:make_struct {a:1} {{ '''abc''' }} {b:2})")
                (text "(:make_struct 123)")
-               (text "(:make_struct {a:1} 123) {b:2}")
+               (text "(:make_struct {a:1} 123 {b:2} )")
                (text "(:make_struct (a 1) )")
-               (text "(:make_struct {a:1} (a 1) ) {b:2}")
+               (text "(:make_struct [] )")
+               (text "(:make_struct () )")
+               (text "(:make_struct {a:1} (a 1) {b:2} )")
+               (text "(:make_struct {a:1} [] {b:2})")
+               (text "(:make_struct {a:1} () {b:2})")
                (signals "invalid argument")))

--- a/conformance/system_macros/make_symbol.ion
+++ b/conformance/system_macros/make_symbol.ion
@@ -20,22 +20,22 @@
          (then "0 values"
                (text '''(:make_symbol)''')
                (produces ''))
-         (then "1 symbol"
+         (then "1 string"
                (text '''(:make_symbol "a")''')
                (produces a))
-         (then "2 symbols"
+         (then "2 strings"
                (text '''(:make_symbol "a" "b")''')
                (produces ab))
-         (then "3 symbols"
+         (then "3 strings"
                (text '''(:make_symbol "a" "b" "c")''')
                (produces abc))
-         (then "1 string"
+         (then "1 symbol"
                (text '''(:make_symbol a)''')
                (produces a))
-         (then "2 strings"
+         (then "2 symbols"
                (text '''(:make_symbol a b)''')
                (produces ab))
-         (then "3 strings"
+         (then "3 symbols"
                (text '''(:make_symbol a b c)''')
                (produces abc))
          (then "a mix of symbols and strings"

--- a/conformance/system_macros/make_symbol.ion
+++ b/conformance/system_macros/make_symbol.ion
@@ -1,8 +1,74 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-// Test Cases:
-// make_symbol can be invoked using any type of macro reference.
-// make_symbol creates a single unannotated symbol from zero or more text values
-// null values, unknown symbol text, and non-text values must signal an error
-// annotations on the argment values are silently dropped
+(ion_1_1 "make_symbol can be invoked"
+         (each "in text with an unqualified macro name"
+               (text " (:make_symbol (::)) ")
+               "in text with an unqualified macro address"
+               (text " (:4 (::)) ")
+               "in text with a qualified macro name"
+               (text " (:$ion::make_symbol (::)) ")
+               "in text using qualified system macro address 4"
+               (text " (:$ion::4 (::)) ")
+               "in binary using system macro address 4"
+               (binary "EF 04 00")
+               "in binary with a user macro address"
+               (binary "04 00")
+               (produces '')))
+
+(ion_1_1 "make_symbol creates a single, unannotated symbol from"
+         (then "0 values"
+               (text '''(:make_symbol)''')
+               (produces ''))
+         (then "1 symbol"
+               (text '''(:make_symbol "a")''')
+               (produces a))
+         (then "2 symbols"
+               (text '''(:make_symbol "a" "b")''')
+               (produces ab))
+         (then "3 symbols"
+               (text '''(:make_symbol "a" "b" "c")''')
+               (produces abc))
+         (then "1 string"
+               (text '''(:make_symbol a)''')
+               (produces a))
+         (then "2 strings"
+               (text '''(:make_symbol a b)''')
+               (produces ab))
+         (then "3 strings"
+               (text '''(:make_symbol a b c)''')
+               (produces abc))
+         (then "a mix of symbols and strings"
+               (text '''(:make_symbol a "b" c "d")''')
+               (produces abcd))
+         (then "an expression that produces multiple text values"
+               (text '''(:make_symbol (:values a "b" c))''')
+               (produces abc))
+         (then "annotated text values"
+               // Argument annotations are silently dropped.
+               (text '''(:make_symbol x::a y::"b" z::c)''')
+               (produces abc)))
+
+(ion_1_1 "the argument cannot be"
+         (each "null"
+               (text ''' (:make_symbol null) ''')
+               (text ''' (:make_symbol "a" null "b") ''')
+               "null.symbol"
+               (text ''' (:make_symbol null.symbol) ''')
+               (text ''' (:make_symbol "a" null.symbol "b") ''')
+               "null.string"
+               (text ''' (:make_symbol null.string) ''')
+               (text ''' (:make_symbol "a" null.string "b") ''')
+               "a non-text value"
+               (text ''' (:make_symbol {{ "abc" }}) ''')
+               (text ''' (:make_symbol 123) ''')
+               (text ''' (:make_symbol ["a", "b", "c"]) ''')
+               (text ''' (:make_symbol "a" {{ "abc" }} "b") ''')
+               (text ''' (:make_symbol "a" 123 "b") ''')
+               (text ''' (:make_symbol "a" ["a", "b", "c"] "b") ''')
+               "a symbol with unknown text"
+               (text ''' (:make_symbol $0) ''')
+               (text ''' (:make_symbol "a" $0 "b") ''')
+               (text ''' (:make_symbol $9999999) ''')
+               (text ''' (:make_symbol "a" $9999999 "b") ''')
+               (signals "invalid argument")))

--- a/conformance/system_macros/make_timestamp.ion
+++ b/conformance/system_macros/make_timestamp.ion
@@ -1,22 +1,305 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-// Test Cases:
-// make_timestamp can be invoked using any type of macro reference.
-// make_timestamp creates a single unannotated timestamp
-// any annotations on the argment values are silently dropped
-// if any argument is null, it should signal an error
-// year must be from 0 to 9999 (inclusive)
-// month must be from 1 to 12 (inclusive)
-// if month is present, year must also be present
-// day must be from 1 to 28,29,30, or 31 (inclusive) depending on the month
-// if day is present, month must also be present
-// hour must be from 0 to 23 (inclusive)
-// if hour is present, minute and day must also be present
-// minute must be from 0 to 59 (inclusive)
-// if minute is present, hour must also be present
-// second must be a decimal value from +0 to 60 (exclusive) with any precision
-// if second is present, minute must also be present
-// offset minutes argument may not be present unless minutes is present.
-// if offset minutes is present, it must be in the range -1440 to 1440 (inclusive)
-// if offset minutes is absent, the resulting timestamp has unknown offset.
+(ion_1_1 "make_timestamp can be invoked"
+         (each "in text with an unqualified macro name"
+               (text " (:make_timestamp 1) ")
+               "in text with an unqualified macro address"
+               (text " (:7 1) ")
+               "in text with a qualified macro name"
+               (text " (:$ion::make_timestamp 1) ")
+               "in text using qualified system macro address 7"
+               (text " (:$ion::7 1) ")
+               "in binary using system macro address 7"
+               (binary "EF 07 00 00 01 00")
+               "in binary with a user macro address"
+               (binary "07 00 00 01 00")
+               (produces 0001T)))
+
+(ion_1_1 "make_timestamp produces a single, unannotated timestamp"
+         (then (text " (:make_timestamp 1) " ) (produces 0001T))
+         (then (text " (:make_timestamp 1 2) " ) (produces 0001-02T))
+         (then (text " (:make_timestamp 1 2 3) " ) (produces 0001-02-03T))
+         (then (text " (:make_timestamp 1 2 3 4 5) " ) (produces 0001-02-03T04:05-00:00))
+         (then (text " (:make_timestamp 1 2 3 4 5 6.) " ) (produces 0001-02-03T04:05:06-00:00))
+         (then (text " (:make_timestamp 1 2 3 4 5 6. 7) " ) (produces 0001-02-03T04:05:06+00:07)))
+
+(ion_1_1 "the arguments may have annotations, which are silently dropped"
+         (each (text " (:make_timestamp a::1 2 3 4 5 6. 7) " )
+               (text " (:make_timestamp 1 b::2 3 4 5 6. 7) " )
+               (text " (:make_timestamp 1 2 c::3 4 5 6. 7) " )
+               (text " (:make_timestamp 1 2 3 d::4 5 6. 7) " )
+               (text " (:make_timestamp 1 2 3 4 e::5 6. 7) " )
+               (text " (:make_timestamp 1 2 3 4 5 f::6. 7) " )
+               (text " (:make_timestamp 1 2 3 4 5 6. g::7) " )
+               (produces 0001-02-03T04:05:06+00:07)))
+
+(ion_1_1 "the year argument"
+         (each "may not be null"
+               (text " (:make_timestamp null 2 3 4 5 6. 7) ")
+               "may not be null.int"
+               (text " (:make_timestamp null.int 2 3 4 5 6. 7) ")
+               "may not be a float"
+               (text " (:make_timestamp 9e0 2 3 4 5 6. 7) ")
+               "may not be a decimal"
+               (text "(:make_timestamp 1.0)")
+               "may not be an empty expression group"
+               (text "(:make_timestamp (::))")
+               "may not be an expression that produces no values"
+               (text "(:make_timestamp (:none))")
+               "may not be multiple values"
+               (text " (:make_timestamp (:: 1 1) 2 3 4 5 6. 7) ")
+               (signals "invalid argument"))
+         (then "is encoded in binary as uint16"
+               (binary "EF 07" // System macro invocation
+                       "00 00" // Presence bitmap
+                       /* Y */ "0F 27")
+               (produces 9999T))
+         (then "must be greater than 0"
+               (then (text "(:make_timestamp 0)") (signals "invalid argument"))
+               (then (text "(:make_timestamp 1)") (produces 0001T)))
+         (then "must be less than or equal to 9999"
+               (then (text "(:make_timestamp 9999)") (produces 9999T))
+               (then (text "(:make_timestamp 10000)") (signals "invalid argument"))))
+
+(ion_1_1 "the month argument"
+         (each "must be be present if day is present"
+               (text "(:make_timestamp 2024 (::) 1)")
+               "may not be null"
+               (text " (:make_timestamp 1 null 3 4 5 6. 7) ")
+               "may not be null.int"
+               (text " (:make_timestamp 1 null.int 3 4 5 6. 7) ")
+               "may not be a float"
+               (text " (:make_timestamp 1 9e0 3 4 5 6. 7) ")
+               "may not be a decimal"
+               (text "(:make_timestamp 2024 1.0)")
+               "may not be multiple values"
+               (text " (:make_timestamp 1 (:: 2 2) 3 4 5 6. 7) ")
+               (signals "invalid argument"))
+         (then "is encoded in binary as uint8"
+               (binary "EF 07"
+                       "01 00"
+                       "0F 27" // Y Y
+                       "0C")
+               (produces 9999-12T))
+         (then "must be greater than 0"
+               (then (text "(:make_timestamp 2024 0)") (signals "invalid argument"))
+               (then (text "(:make_timestamp 2024 1)") (produces 2024-01T)))
+         (then "must be less than or equal to 12"
+               (then (text "(:make_timestamp 2024 12)") (produces 2024-12T))
+               (then (text "(:make_timestamp 2024 13)") (signals "invalid argument"))))
+
+(ion_1_1 "the day argument"
+         (then "must be present if hour and minute are present"
+               (text "(:make_timestamp 2024 2 (::) 12 30)")
+               (signals "invalid argument"))
+         (each "may not be null"
+               (text " (:make_timestamp 1 2 null 4 5 6. 7) ")
+               "may not be null.int"
+               (text " (:make_timestamp 1 2 null.int 4 5 6. 7) ")
+               "may not be a float"
+               (text " (:make_timestamp 1 2 3e0 4 5 6. 7) ")
+               "may not be a decimal"
+               (text "(:make_timestamp 2024 2 1.0)")
+               "may not be multiple values"
+               (text " (:make_timestamp 1 2 (:: 3 3) 4 5 6. 7) ")
+               (signals "invalid argument"))
+         (then "is encoded in binary as uint8"
+               (binary "EF 07"
+                       "05 00"
+                       "0F 27 0C" // Y Y M
+                       "1F")
+               (produces 9999-12-31T))
+         (then "must be greater than 0"
+               (then (text "(:make_timestamp 2024 2 0)") (signals "invalid argument"))
+               (then (text "(:make_timestamp 2024 2 1)") (produces 2024-02-01T)))
+         (then "must be less than or equal to 31 in months with 31 days"
+               (then (text "(:make_timestamp 2024  1 31)") (produces 2024-01-31T))
+               (then (text "(:make_timestamp 2024  3 31)") (produces 2024-03-31T))
+               (then (text "(:make_timestamp 2024  5 31)") (produces 2024-05-31T))
+               (then (text "(:make_timestamp 2024  7 31)") (produces 2024-07-31T))
+               (then (text "(:make_timestamp 2024  8 31)") (produces 2024-08-31T))
+               (then (text "(:make_timestamp 2024 10 31)") (produces 2024-10-31T))
+               (then (text "(:make_timestamp 2024 12 31)") (produces 2024-12-31T))
+               (each (text "(:make_timestamp 2024  1 32)")
+                     (text "(:make_timestamp 2024  3 32)")
+                     (text "(:make_timestamp 2024  5 32)")
+                     (text "(:make_timestamp 2024  7 32)")
+                     (text "(:make_timestamp 2024  8 32)")
+                     (text "(:make_timestamp 2024 10 32)")
+                     (text "(:make_timestamp 2024 12 32)")
+                     (signals "invalid argument")))
+         (then "must be less than or equal to 30 in months with 30 days"
+               (then (text "(:make_timestamp 2024  4 30)") (produces 2024-04-30T))
+               (then (text "(:make_timestamp 2024  6 30)") (produces 2024-06-30T))
+               (then (text "(:make_timestamp 2024  9 30)") (produces 2024-09-30T))
+               (then (text "(:make_timestamp 2024 11 30)") (produces 2024-11-30T))
+               (each (text "(:make_timestamp 2024  4 31)")
+                     (text "(:make_timestamp 2024  6 31)")
+                     (text "(:make_timestamp 2024  9 31)")
+                     (text "(:make_timestamp 2024 11 31)")
+                     (signals "invalid argument")))
+         (then "must be less than or equal to 29 for Februarys with 29 days"
+               (then (text "(:make_timestamp 2020  2 29)") (produces 2020-02-29T))
+               (then (text "(:make_timestamp 2024  2 29)") (produces 2024-02-29T))
+               (each (text "(:make_timestamp 2020  2 30)")
+                     (text "(:make_timestamp 2024  2 30)")
+                     (signals "invalid argument")))
+         (then "must be less than or equal to 28 for Februarys with 28 days"
+               (then (text "(:make_timestamp 2100  2 28)") (produces 2100-02-28T))
+               (then (text "(:make_timestamp 2023  2 28)") (produces 2023-02-28T))
+               (each (text "(:make_timestamp 2100  2 29)")
+                     (text "(:make_timestamp 2023  2 29)")
+                     (signals "invalid argument"))))
+
+(ion_1_1 "the hour argument"
+         (then "must be be present if minute is present"
+               (text "(:make_timestamp 2024 2 3 (::) 30)")
+               (signals "invalid argument"))
+         (each "may not be null"
+               (text " (:make_timestamp 1 2 3 null 5 6. 7) ")
+               "may not be null.int"
+               (text " (:make_timestamp 1 2 3 null.int 5 6. 7) ")
+               "may not be a float"
+               (text " (:make_timestamp 1 2 3 4e0 5 6. 7) ")
+               "may not be a decimal"
+               (text "(:make_timestamp 2024 2 3 1.0 30)")
+               "may not be multiple values"
+               (text " (:make_timestamp 1 2 3 (:: 4 4) 5 6. 7) ")
+               (signals "invalid argument"))
+         (then "must be greater than or equal to 0"
+               (then (text "(:make_timestamp 2024 2 3 -1 0)") (signals "invalid argument"))
+               (then (text "(:make_timestamp 2024 2 3 0 0)") (produces 2024-02-03T00:00-00:00)))
+         (then "must be less than 24"
+               (then (text "(:make_timestamp 2024 2 3 23 0)") (produces 2024-02-03T23:00-00:00)))
+               (then (text "(:make_timestamp 2024 2 3 24 0)") (signals "invalid argument")))
+
+(ion_1_1 "the minute argument"
+         (each "must be be present if hour is present"
+               (text "(:make_timestamp 2024 2 3 4 (::))")
+               "must be be present if second is present"
+               (text "(:make_timestamp 2024 2 3 (::) (::) 5.0)")
+               "may not be null"
+               (text " (:make_timestamp 1 2 3 4 null 6. 7) ")
+               "may not be null.int"
+               (text " (:make_timestamp 1 2 3 4 null.int 6. 7) ")
+               "may not be a float"
+               (text " (:make_timestamp 1 2 3 4 5e0 6. 7) ")
+               "may not be a decimal"
+               (text "(:make_timestamp 2024 2 3 4 1.0)")
+               "may not be multiple values"
+               (text " (:make_timestamp 1 2 3 4 (:: 5 5) 6. 7) ")
+               (signals "invalid argument"))
+         (then "must be greater than or equal to 0"
+               (then (text "(:make_timestamp 2024 2 3 4 -1)") (signals "invalid argument"))
+               (then (text "(:make_timestamp 2024 2 3 4  0)") (produces 2024-02-03T04:00-00:00)))
+         (then "must be less than 60"
+               (then (text "(:make_timestamp 2024 2 3 4 59)") (produces 2024-02-03T04:59-00:00))
+               (then (text "(:make_timestamp 2024 2 3 4 60)") (signals "invalid argument"))))
+
+(ion_1_1 "the hour and minute arguments are encoded in binary as uint8"
+         // We can't test the hour and minute arguments separately for this case
+         (binary "EF 07"
+                 "55 00"
+                 "0F 27 0C 1F" // Y Y M D
+                 "17 3B")
+         (produces 9999-12-31T23:59-00:00))
+
+(ion_1_1 "the seconds argument"
+         (each "may not be null"
+               (text " (:make_timestamp 1 2 3 4 5 null 7) ")
+               "may not be null.decimal"
+               (text " (:make_timestamp 1 2 3 4 5 null.decimal 7) ")
+               "may not be a float"
+               (text " (:make_timestamp 1 2 3 4 5 6e0 7) ")
+               "may not be an integer"
+               (text "(:make_timestamp 2024 2 3 4 5 6)")
+               "may not be multiple values"
+               (text " (:make_timestamp 1 2 3 4 5 (:: 6. 6.) 7) ")
+               (signals "invalid argument"))
+         (then "in binary"
+               (then "is a tagged value"
+                     (binary "EF 07"
+                             "55 01"
+                             "0F 27 0C 1F" // Y Y M D
+                             "17 3B"       // H m
+                             "70")
+                     (produces 9999-12-31T23:59:00-00:00))
+               (then "may not be a tagged integer"
+                     (binary "EF 07"
+                             "55 01"
+                             "0F 27 0C 1F" // Y Y M D
+                             "17 3B"       // H m
+                             "60")
+                     (signals "invalid argument")))
+         (then "must be a positive value"
+               (then (text "(:make_timestamp 2024 2 3 4 5 -0.1)")
+                     (signals "invalid argument"))
+               (each (text "(:make_timestamp 2024 2 3 4 5 -0.)")
+                     (text "(:make_timestamp 2024 2 3 4 5 0.)")
+                     (produces 2024-02-03T04:05:00-00:00)))
+         (then "must be less than 60"
+               (then (text "(:make_timestamp 2024 2 3 4 5 59.9)") (produces 2024-02-03T04:05:59.9-00:00))
+               (then (text "(:make_timestamp 2024 2 3 4 5 60.0)") (signals "invalid argument")) )
+         (then "can have any precision"
+               (then (text "(:make_timestamp 2024 2 3 4 5 0d10)") (produces 2024-02-03T04:05:00-00:00))
+               (then (text "(:make_timestamp 2024 2 3 4 5 3d1)") (produces 2024-02-03T04:05:30-00:00))
+               (then (text "(:make_timestamp 2024 2 3 4 5 6.)") (produces 2024-02-03T04:05:06-00:00))
+               (then (text "(:make_timestamp 2024 2 3 4 5 6.7)") (produces 2024-02-03T04:05:06.7-00:00))
+               (then (text "(:make_timestamp 2024 2 3 4 5 6.70)") (produces 2024-02-03T04:05:06.70-00:00))))
+
+(ion_1_1 "the offset argument"
+         (then "when absent, indicates unknown offset"
+               (text "(:make_timestamp 2024 2 3 4 5)")
+               (produces 2024-02-03T04:05-00:00))
+         (then "when zero, indicates utc offset"
+               (text "(:make_timestamp 2024 2 3 4 5 (::) 0)")
+               (produces 2024-02-03T04:05Z))
+         (each "may only be present if hour and minute are present"
+               (text "(:make_timestamp 2024 (::) (::) (::) (::) (::) 60)")
+               (text "(:make_timestamp 2024 2 (::) (::) (::) (::) 60)")
+               (text "(:make_timestamp 2024 2 3 (::) (::) (::) 60)")
+               "may not be null"
+               (text " (:make_timestamp 1 2 3 4 5 6. null) ")
+               "may not be null.int"
+               (text " (:make_timestamp 1 2 3 4 5 6. null.int) ")
+               "may not be a float"
+               (text " (:make_timestamp 1 2 3 4 5 6. 7e0) ")
+               "may not be a decimal"
+               (text "(:make_timestamp 2024 2 3 4 5 6.0 7.0)")
+               "may not be multiple values"
+               (text "(:make_timestamp 1 2 3 4 5 6. (:: 7 7))")
+               (signals "invalid argument"))
+         (then "is encoded in binary as an int16"
+               (then (binary "EF 07 55 05"
+                             "0F 27 0C 1E 17 3B 70"    // Y Y M D H m s
+                             "00 00")
+                     (produces 9999-12-30T23:59:00Z))
+               (then (binary "EF 07 55 05"
+                             "0F 27 0C 1E 17 3B 70"    // Y Y M D H m s
+                             "11 11")
+                     (produces 9999-12-30T23:59:00-00:01))
+               (then (binary "EF 07 55 05"
+                             "0F 27 0C 1E 17 3B 70"    // Y Y M D H m s
+                             "01 00")
+                     (produces 9999-12-30T23:59:00+00:01))
+               (then (binary "EF 07 55 05"
+                             "0F 27 0C 1F 17 3B 70"    // Y Y M D H m s
+                             "61 FA")
+                     (produces 9999-12-30T23:59:00-23:59))
+               (then (binary "EF 07 55 05"
+                             "0F 27 0C 1F 17 3B 70"    // Y Y M D H m s
+                             "9F 05")
+                     (produces 9999-12-30T23:59:00+23:59)))
+         (then "must be greater than -1440"
+               (then (text "(:make_timestamp 2024 2 3 4 5 (::) -1440)") (signals "invalid argument"))
+               (then (text "(:make_timestamp 2024 2 3 4 5 (::) -1439)") (produces 2024-02-03T04:05-23:59)))
+         (then "must be less than 1440"
+               (then (text "(:make_timestamp 2024 2 3 4 5 (::) 1439)") (produces 2024-02-03T04:05+23:59)))
+               (then (text "(:make_timestamp 2024 2 3 4 5 (::) 1440)") (signals "invalid argument"))
+         (then "may not cause the year, in UTC, to be less than 0001"
+               (text "(:make_timestamp 1 1 1 0 0 0. 1439)")
+               (signals "year cannot be less than 1"))
+         (then "may not cause the year, in UTC, to be more than 9999"
+               (text "(:make_timestamp 9999 12 31 23 59 0. -1439)")
+               (signals "year exceeds 9999")))


### PR DESCRIPTION
**Issue #, if available:**

#88 

**Description of changes:**

Adds actual test cases for all of the `make_*` system macros.

Things to review:
* Do the test cases accurately implement the descriptions?
* Are there any edge cases that are missing?
* Are the parameter encoding tests for `make_timestamp` correct? (I think they are, but I need confirmation.)


_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
