### PR TITLE
Adds test cases for sum and delta system macros

### DIFF
--- a/conformance/system_macros/delta.ion
+++ b/conformance/system_macros/delta.ion
@@ -1,12 +1,67 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-// Test Cases:
-// delta can be invoked using any type of macro reference.
-// the arguments of delta must be non-null integers
-// the "initial" argument is required
-// the "delta" argument can be zero or more values
-// any annotations on the arguments are silently dropped
+(ion_1_1 "delta can be invoked"
+         (each "in text with an unqualified macro name"
+               (text "(:delta)")
+               "in text with an unqualified macro address"
+               (text "(:18)")
+               "in text with a qualified macro name"
+               (text "(:$ion::delta)")
+               "in text with a qualified macro address"
+               (text "(:$ion::18)")
+               "in binary with a system macro address"
+               (binary "EF 12 00")
+               "in binary with a user macro address"
+               (binary "12 00")
+               (produces)))
+
 // the output of delta is defined as follows:
-//    output₀ = initial + delta₀
+//    output₀ = delta₀
 //    outputₙ₊₁ = outputₙ + deltaₙ₊₁
+(ion_1_1 "delta produces a stream of values that is the delta of"
+         (each "0 arguments"
+               (binary "EF 12 00")
+               (text "(:delta)")
+               (text "(:delta (::))")
+               (produces))
+         (each "1 argument"
+               (binary "EF 12 01 03")
+               (text "(:delta 1)")
+               (produces 1))
+         (each "2 arguments"
+               (binary "EF 12 02 05 03 05 01")
+               (text "(:delta 1 2)")
+               (produces 1 3))
+         (each "3 arguments"
+               (binary "EF 12 02 07 FF FF FF 01")
+               (text "(:delta -1 -1 -1)")
+               (produces -1 -2 -3))
+         (each "4 arguments"
+               (binary "EF 12 02 09 03 03 03 03 01")
+               (text "(:delta 1 1 1 1)")
+               (text "(:delta (:repeat 4 1))")
+               (produces 1 2 3 4))
+         (each "many arguments"
+               (text "(:delta 1 2 3 4 5 -1 -2 -3)")
+               // Annotations are silently dropped
+               (text "(:delta a::1 b::2 c::3 d::4 e::5 -1 -2 -3)")
+               (produces 1 3 6 10 15 14 12 9)))
+
+(ion_1_1 "arguments may not be"
+         (each "any null"
+               (text "(:delta 1 null 2)")
+               (text "(:delta 1 null.int 2)")
+               (text "(:delta 1 null.float 2)")
+               (text "(:delta 1 null.decimal 2)")
+               "a float"
+               (text "(:delta 1 3e1 2)")
+               "a decimal"
+               (text "(:delta 1 3d1 2)")
+               "a list of numbers"
+               (text "(:delta 1 [3, 4, 5] 2)")
+               "a sexp of numbers"
+               (text "(:delta 1 (3 4 5) 2)")
+               "a numeric string"
+               (text "(:delta 1 '''3''' 2)")
+               (signals "invalid argument")))

--- a/conformance/system_macros/delta.ion
+++ b/conformance/system_macros/delta.ion
@@ -65,3 +65,20 @@
                "a numeric string"
                (text "(:delta 1 '''3''' 2)")
                (signals "invalid argument")))
+
+// Demonstrations of some interesting things you can do with delta.
+
+(ion_1_1 "delta and repeat can be combined to generate"
+         (mactab $ion_encoding (macro from_x_count_n_by_step (x n step) (.delta (.. (%x) (.repeat (%n) (%step))))))
+         (then "an increasing sequence"   (text "(:from_x_count_n_by_step 0 10  1)") (produces 0 1 2 3 4 5 6 7 8 9 10))
+         (then "a count-by-twos sequence" (text "(:from_x_count_n_by_step 0 10  2)") (produces 0 2 4 6 8 10 12 14 16 18 20))
+         (then "a decreasing sequence"    (text "(:from_x_count_n_by_step 5 10 -1)") (produces 5 4 3 2 1 0 -1 -2 -3 -4 -5)))
+
+(ion_1_1 "it is possible to create a delta of deltas encoding"
+         // See, for example
+         // https://www.timescale.com/blog/time-series-compression-algorithms-explained/#delta-of-delta-encoding
+         (mactab $ion_encoding
+                 (macro delta_of_deltas (flex_int::init dod*) (.delta (.. (%init) (.delta (%dod)))))
+                 (macro rle (flex_uint::run_length flex_int::value) (.repeat (%run_length) (%value))))
+         (text "(:delta_of_deltas 52 (:: -1 (:rle 10 0) 1 (:rle 5 0) 1 (:rle 5 0)))")
+         (produces 52 51 50 49 48 47 46 45 44 43 42 41 41 41 41 41 41 41 42 43 44 45 46 47))

--- a/conformance/system_macros/sum.ion
+++ b/conformance/system_macros/sum.ion
@@ -1,8 +1,54 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-// Test Cases:
-// sum can be invoked using any type of macro reference.
-// the arguments of sum must be zero or more non-null integers
-// any annotations on the arguments are silently dropped
-// the output of sum is the sum of all its argument values
+(ion_1_1 "sum can be invoked"
+         (each "in text with an unqualified macro name"
+               (text "(:sum)")
+               "in text with an unqualified macro address"
+               (text "(:20)")
+               "in text with a qualified macro name"
+               (text "(:$ion::sum)")
+               "in text with a qualified macro address"
+               (text "(:$ion::20)")
+               "in binary with a system macro address"
+               (binary "EF 14 00")
+               "in binary with a user macro address"
+               (binary "14 00")
+               (produces 0)))
+
+(ion_1_1 "sum produces a single value that is the sum of"
+         (each "zero arguments"
+               (binary "EF 14 00")
+               (text "(:sum)")
+               (text "(:sum (::))")
+               (produces 0))
+         (then "one argument"
+               (binary "EF 14 01 03")
+               (text "(:sum 1)")
+               (produces 1))
+         (each "multiple arguments"
+               (binary "EF 14 02 09 61 08 61 07")
+               (text "(:sum 1 2 3 4 5)")
+               (text "(:sum 0 15)")
+               (text "(:sum 10 10 -2 -3)")
+               // Annotations are silently dropped
+               (text "(:sum a::1 b::2 c::3 d::4 e::5)")
+               (produces 15)))
+
+(ion_1_1 "arguments may not be"
+         (each "any null"
+               (text "(:sum 1 null 2)")
+               (text "(:sum 1 null.int 2)")
+               (text "(:sum 1 null.float 2)")
+               (text "(:sum 1 null.decimal 2)")
+               "a float"
+               (text "(:sum 1 3e1 2)")
+               "a decimal"
+               (text "(:sum 1 3d1 2)")
+               "a list of numbers"
+               (text "(:sum 1 [3, 4, 5] 2)")
+               "a sexp of numbers"
+               (text "(:sum 1 (3 4 5) 2)")
+               "a numeric string"
+               (text "(:sum 1 '''3''' 2)")
+               (signals "invalid argument")))

--- a/conformance/system_macros/sum.ion
+++ b/conformance/system_macros/sum.ion
@@ -3,52 +3,74 @@
 
 (ion_1_1 "sum can be invoked"
          (each "in text with an unqualified macro name"
-               (text "(:sum)")
+               (text "(:sum 0 0)")
                "in text with an unqualified macro address"
-               (text "(:20)")
+               (text "(:20 0 0)")
                "in text with a qualified macro name"
-               (text "(:$ion::sum)")
+               (text "(:$ion::sum 0 0)")
                "in text with a qualified macro address"
-               (text "(:$ion::20)")
+               (text "(:$ion::20 0 0)")
                "in binary with a system macro address"
-               (binary "EF 14 00")
+               (binary "EF 14 60 60")
                "in binary with a user macro address"
-               (binary "14 00")
+               (binary "14 60 60")
                (produces 0)))
 
-(ion_1_1 "sum produces a single value that is the sum of"
-         (each "zero arguments"
-               (binary "EF 14 00")
-               (text "(:sum)")
-               (text "(:sum (::))")
-               (produces 0))
-         (then "one argument"
-               (binary "EF 14 01 03")
-               (text "(:sum 1)")
-               (produces 1))
-         (each "multiple arguments"
-               (binary "EF 14 02 09 61 08 61 07")
-               (text "(:sum 1 2 3 4 5)")
-               (text "(:sum 0 15)")
-               (text "(:sum 10 10 -2 -3)")
-               // Annotations are silently dropped
-               (text "(:sum a::1 b::2 c::3 d::4 e::5)")
-               (produces 15)))
+(ion_1_1 "sum produces a single, unannotated integer that is the sum of"
+         (each "two integers"
+               (text "(:sum -1  4)")
+               (text "(:sum  0  3)")
+               (text "(:sum  1  2)")
+               (text "(:sum  2  1)")
+               (text "(:sum  3  0)")
+               (text "(:sum  4 -1)")
+               "annotated integers"
+               (text "(:sum a::1 2)")
+               (text "(:sum 1 b::2)")
+               (text "(:sum a::1 b::2)")
+               // Values that produce an integer
+               (text "(:sum (:values 1) 2)")
+               (text "(:sum 1 (:values 2))")
+               // ...including other sums
+               (text "(:sum (:sum 1 1) 1)")
+               (text "(:sum 1 (:sum 1 1))")
+               (produces 3)))
+
+(ion_1_1 "sum is commutative"
+         (each (text "(:sum  1  0)") (text "(:sum  0  1)") (produces  1))
+         (each (text "(:sum -1  0)") (text "(:sum  0 -1)") (produces -1))
+         (each (text "(:sum -1  1)") (text "(:sum  1 -1)") (produces  0))
+         (each (text "(:sum  3  7)") (text "(:sum  7  3)") (produces 10))
+         (each (text "(:sum -3 -5)") (text "(:sum -5 -3)") (produces -8))
+         (each (text "(:sum -2  4)") (text "(:sum  4 -2)") (produces  2)))
 
 (ion_1_1 "arguments may not be"
          (each "any null"
-               (text "(:sum 1 null 2)")
-               (text "(:sum 1 null.int 2)")
-               (text "(:sum 1 null.float 2)")
-               (text "(:sum 1 null.decimal 2)")
+               (text "(:sum 1 null)")
+               (text "(:sum 1 null.int)")
+               (text "(:sum 1 null.float)")
+               (text "(:sum 1 null.decimal)")
+               (text "(:sum null 2)")
+               (text "(:sum null.int 2)")
+               (text "(:sum null.float 2)")
+               (text "(:sum null.decimal 2)")
                "a float"
-               (text "(:sum 1 3e1 2)")
+               (text "(:sum 1 3e1)")
+               (text "(:sum 3e1 2)")
                "a decimal"
-               (text "(:sum 1 3d1 2)")
+               (text "(:sum 1 3d1)")
+               (text "(:sum 3d1 2)")
                "a list of numbers"
-               (text "(:sum 1 [3, 4, 5] 2)")
+               (text "(:sum 1 [3])")
+               (text "(:sum [3] 2)")
+               (text "(:sum [1, 2])")
                "a sexp of numbers"
-               (text "(:sum 1 (3 4 5) 2)")
-               "a numeric string"
-               (text "(:sum 1 '''3''' 2)")
+               (text "(:sum 1 (3))")
+               (text "(:sum (3) 2)")
+               (text "(:sum (1 2))")
+               "a numeric text value"
+               (text '''(:sum 1 "3")''')
+               (text '''(:sum 1 '3')''')
+               (text '''(:sum "3" 2)''')
+               (text '''(:sum '3' 2)''')
                (signals "invalid argument")))

--- a/conformance/system_macros/sum.ion
+++ b/conformance/system_macros/sum.ion
@@ -17,7 +17,7 @@
                (produces 0)))
 
 (ion_1_1 "sum produces a single, unannotated integer that is the sum of"
-         (each "two integers"
+         (each "integers"
                (text "(:sum -1  4)")
                (text "(:sum  0  3)")
                (text "(:sum  1  2)")
@@ -28,12 +28,13 @@
                (text "(:sum a::1 2)")
                (text "(:sum 1 b::2)")
                (text "(:sum a::1 b::2)")
-               // Values that produce an integer
+               "expressions that produce integers"
                (text "(:sum (:values 1) 2)")
                (text "(:sum 1 (:values 2))")
-               // ...including other sums
+               "other sums"
                (text "(:sum (:sum 1 1) 1)")
                (text "(:sum 1 (:sum 1 1))")
+               (text "(:sum (:sum -4 3) (:sum 2 2))")
                (produces 3)))
 
 (ion_1_1 "sum is commutative"
@@ -45,7 +46,12 @@
          (each (text "(:sum -2  4)") (text "(:sum  4 -2)") (produces  2)))
 
 (ion_1_1 "arguments may not be"
-         (each "any null"
+         (each "less than two integers"
+               (text "(:sum)")
+               (text "(:sum 1)")
+               "more than two integers"
+               (text "(:sum 1 2 3)")
+               "any null"
                (text "(:sum 1 null)")
                (text "(:sum 1 null.int)")
                (text "(:sum 1 null.float)")
@@ -73,4 +79,6 @@
                (text '''(:sum 1 '3')''')
                (text '''(:sum "3" 2)''')
                (text '''(:sum '3' 2)''')
+               "a single expression that produces two integers"
+               (text "(:sum (:values 1 3))")
                (signals "invalid argument")))


### PR DESCRIPTION
**Issue #, if available:**

#88 

**Description of changes:**

Adds test cases for `sum` and `delta`.

As I was writing the test cases, it seemed really odd that `sum` can have zero-to-many argument values, but `delta` cannot. So, I made a decision to change that, and in these test cases, `delta` accepts zero-to-many argument values, and the _implicit_ initial value is zero. (Just like `sum`.)

If there's disagreement, I can revert back to the currently spec'd behavior. If we agree, then I can update the spec accordingly.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
