### PR TITLE
Fix parameter types for system macros and improve some tests names

### DIFF
--- a/conformance/local_symtab_imports.ion
+++ b/conformance/local_symtab_imports.ion
@@ -34,7 +34,7 @@
         (signals "No exact-match for empty@2")))
 
 
-(ion_1_0 "When max_id is valid, pad/truncade mismatched or absent SSTs"
+(ion_1_0 "When max_id is valid, pad/truncate mismatched or absent SSTs"
   (then (toplevel $ion_symbol_table::{imports:[{name:"absent", max_id:0}, {name:"abcs"}]}
                   '#$10')
         (produces a))

--- a/conformance/system_macros/delta.ion
+++ b/conformance/system_macros/delta.ion
@@ -26,19 +26,19 @@
                (text "(:delta (::))")
                (produces))
          (each "1 argument"
-               (binary "EF 12 01 03")
+               (binary "EF 12 01 61 01")
                (text "(:delta 1)")
                (produces 1))
          (each "2 arguments"
-               (binary "EF 12 02 05 03 05 01")
+               (binary "EF 12 02 09 61 01 61 02")
                (text "(:delta 1 2)")
                (produces 1 3))
          (each "3 arguments"
-               (binary "EF 12 02 07 FF FF FF 01")
+               (binary "EF 12 02 0D 61 FF 61 FF 61 FF")
                (text "(:delta -1 -1 -1)")
                (produces -1 -2 -3))
          (each "4 arguments"
-               (binary "EF 12 02 09 03 03 03 03 01")
+               (binary "EF 12 02 11 61 01 61 01 61 01 61 01")
                (text "(:delta 1 1 1 1)")
                (text "(:delta (:repeat 4 1))")
                (produces 1 2 3 4))

--- a/conformance/system_macros/make_decimal.ion
+++ b/conformance/system_macros/make_decimal.ion
@@ -34,14 +34,12 @@
                (text " (:make_decimal 0 (:: 1 2)) ")
                (signals "invalid argument")))
 
-(ion_1_1 "in binary both arguments are encoded as flex_int"
-         (then (binary "EF 06 01    01   ") (produces 0d0))
-         (then (binary "EF 06 03    03   ") (produces 1d1))
-         (then (binary "EF 06 06 00 06 00") (produces 1d1))
-         (then (binary "EF 06 9E F4 01   ") (produces -729d0))
-         (then (binary "EF 06 01    9E F4") (produces 0d-729))
-         (then (binary "EF 06 FF    FF   ") (produces -1d-1))
-         (then (binary "EF 06 FE FF FE FF") (produces -1d-1)))
+(ion_1_1 "in binary both arguments are encoded as tagged values"
+         (then (binary "EF 06 60    60   ") (produces 0d0))
+         (then (binary "EF 06 61 01 61 01") (produces 1d1))
+         (then (binary "EF 06 61 FF 61 01") (produces -1d1))
+         (then (binary "EF 06 61 01 61 FF") (produces 1d-1))
+         (then (binary "EF 06 61 FF 61 FF") (produces -1d-1)))
 
 (ion_1_1 "make_decimal creates a single unannotated decimal"
          (then (text "(:make_decimal -3 1)") (produces -3d1))
@@ -60,5 +58,8 @@
          (then (text "(:make_decimal 2  1)") (produces 2d1))
          (then (text "(:make_decimal 2  2)") (produces 2d2))
          (then (text "(:make_decimal 2  3)") (produces 2d3))
+         // Arguments can be e-expressions
+         (then (text "(:make_decimal (:values 2) 3)") (produces 2d3))
+         (then (text "(:make_decimal 2 (:values 3))") (produces 2d3))
          // Argument annotations are silently dropped.
          (then (text "(:make_decimal a::3  b::3)") (produces 3d3)))

--- a/conformance/system_macros/make_field.ion
+++ b/conformance/system_macros/make_field.ion
@@ -11,9 +11,9 @@
                "in text using qualified system macro address 22"
                (text " (:$ion::22 foo 0) ")
                "in binary using system macro address 22"
-               (binary "EF 16 FB 66 6F 6F 60")
+               (binary "EF 16 A3 66 6F 6F 60")
                "in binary with a user macro address"
-               (binary "16 FB 66 6F 6F 60")
+               (binary "16 A3 66 6F 6F 60")
                (produces {foo: 0} )))
 
 (ion_1_1 "the first argument"

--- a/conformance/system_macros/make_timestamp.ion
+++ b/conformance/system_macros/make_timestamp.ion
@@ -79,7 +79,7 @@
          (then "is encoded in binary as a tagged value"
                (binary "EF 07"
                        "01 00"
-                       "62 0F 27" // Y Y
+                       "62 0F 27" // Y Y Y
                        "61 0C")
                (produces 9999-12T))
          (then "must be greater than 0"
@@ -107,7 +107,7 @@
          (then "is encoded in binary as a tagged value"
                (binary "EF 07"
                        "05 00"
-                       "62 0F 27 61 0C" // Y Y M
+                       "62 0F 27 61 0C" // Y Y Y M M
                        "61 1F")
                (produces 9999-12-31T))
          (then "must be greater than 0"
@@ -201,7 +201,7 @@
          // We can't test the hour and minute arguments separately for this case
          (binary "EF 07"
                  "55 00"
-                 "62 0F 27 61 0C 61 1F" // Y Y M D
+                 "62 0F 27 61 0C 61 1F" // Y Y Y M M D D
                  "61 17 61 3B")
          (produces 9999-12-31T23:59-00:00))
 
@@ -219,14 +219,14 @@
                (each "may be a tagged decimal"
                      (binary "EF 07"
                              "55 01"
-                             "62 0F 27 61 0C 61 1F" // Y Y M D
-                             "61 17 61 3B"             // H m
+                             "62 0F 27 61 0C 61 1F" // Y Y Y M M D D
+                             "61 17 61 3B"             // H H m m
                              "70")
                      "may be a tagged integer"
                      (binary "EF 07"
                              "55 01"
-                             "62 0F 27 61 0C 61 1F" // Y Y M D
-                             "61 17 61 3B"             // H m
+                             "62 0F 27 61 0C 61 1F" // Y Y Y M M D D
+                             "61 17 61 3B"             // H H m m
                              "60")
                      (produces 9999-12-31T23:59:00-00:00)))
          (then "must be a positive value"
@@ -269,23 +269,23 @@
                (signals "invalid argument"))
          (then "is encoded in binary as a tagged value"
                (then (binary "EF 07 55 05"
-                             "62 0F 27 61 0C 61 1E 61 17 61 3B 70"    // Y Y M D H m s
+                             "62 0F 27 61 0C 61 1E 61 17 61 3B 70"    // Y Y Y M M D D H H m m s
                              "60")
                      (produces 9999-12-30T23:59:00Z))
                (then (binary "EF 07 55 05"
-                             "62 0F 27 61 0C 61 1E 61 17 61 3B 70"    // Y Y M D H m s
+                             "62 0F 27 61 0C 61 1E 61 17 61 3B 70"    // Y Y Y M M D D H H m m s
                              "61 FF")
                      (produces 9999-12-30T23:59:00-00:01))
                (then (binary "EF 07 55 05"
-                             "62 0F 27 61 0C 61 1E 61 17 61 3B 70"    // Y Y M D H m s
+                             "62 0F 27 61 0C 61 1E 61 17 61 3B 70"    // Y Y Y M M D D H H m m s
                              "61 01")
                      (produces 9999-12-30T23:59:00+00:01))
                (then (binary "EF 07 55 05"
-                             "62 0F 27 61 0C 61 1E 61 17 61 3B 70"    // Y Y M D H m s
+                             "62 0F 27 61 0C 61 1E 61 17 61 3B 70"    // Y Y Y M M D D H H m m s
                              "62 61 FA")
                      (produces 9999-12-30T23:59:00-23:59))
                (then (binary "EF 07 55 05"
-                             "62 0F 27 61 0C 61 1E 61 17 61 3B 70"    // Y Y M D H m s
+                             "62 0F 27 61 0C 61 1E 61 17 61 3B 70"    // Y Y Y M M D D H H m m s
                              "62 9F 05")
                      (produces 9999-12-30T23:59:00+23:59)))
          (then "must be greater than -1440"

--- a/conformance/system_macros/make_timestamp.ion
+++ b/conformance/system_macros/make_timestamp.ion
@@ -11,9 +11,9 @@
                "in text using qualified system macro address 7"
                (text " (:$ion::7 1) ")
                "in binary using system macro address 7"
-               (binary "EF 07 00 00 01 00")
+               (binary "EF 07 00 00 61 01")
                "in binary with a user macro address"
-               (binary "07 00 00 01 00")
+               (binary "07 00 00 61 01")
                (produces 0001T)))
 
 (ion_1_1 "make_timestamp produces a single, unannotated timestamp"
@@ -50,10 +50,10 @@
                "may not be multiple values"
                (text " (:make_timestamp (:: 1 1) 2 3 4 5 6. 7) ")
                (signals "invalid argument"))
-         (then "is encoded in binary as uint16"
+         (then "is encoded in binary as a tagged value"
                (binary "EF 07" // System macro invocation
                        "00 00" // Presence bitmap
-                       /* Y */ "0F 27")
+                       /* Y */ "62 0F 27")
                (produces 9999T))
          (then "must be greater than 0"
                (then (text "(:make_timestamp 0)") (signals "invalid argument"))
@@ -76,11 +76,11 @@
                "may not be multiple values"
                (text " (:make_timestamp 1 (:: 2 2) 3 4 5 6. 7) ")
                (signals "invalid argument"))
-         (then "is encoded in binary as uint8"
+         (then "is encoded in binary as a tagged value"
                (binary "EF 07"
                        "01 00"
-                       "0F 27" // Y Y
-                       "0C")
+                       "62 0F 27" // Y Y
+                       "61 0C")
                (produces 9999-12T))
          (then "must be greater than 0"
                (then (text "(:make_timestamp 2024 0)") (signals "invalid argument"))
@@ -104,11 +104,11 @@
                "may not be multiple values"
                (text " (:make_timestamp 1 2 (:: 3 3) 4 5 6. 7) ")
                (signals "invalid argument"))
-         (then "is encoded in binary as uint8"
+         (then "is encoded in binary as a tagged value"
                (binary "EF 07"
                        "05 00"
-                       "0F 27 0C" // Y Y M
-                       "1F")
+                       "62 0F 27 61 0C" // Y Y M
+                       "61 1F")
                (produces 9999-12-31T))
          (then "must be greater than 0"
                (then (text "(:make_timestamp 2024 2 0)") (signals "invalid argument"))
@@ -197,12 +197,12 @@
                (then (text "(:make_timestamp 2024 2 3 4 59)") (produces 2024-02-03T04:59-00:00))
                (then (text "(:make_timestamp 2024 2 3 4 60)") (signals "invalid argument"))))
 
-(ion_1_1 "the hour and minute arguments are encoded in binary as uint8"
+(ion_1_1 "the hour and minute arguments are encoded in binary as tagged values"
          // We can't test the hour and minute arguments separately for this case
          (binary "EF 07"
                  "55 00"
-                 "0F 27 0C 1F" // Y Y M D
-                 "17 3B")
+                 "62 0F 27 61 0C 61 1F" // Y Y M D
+                 "61 17 61 3B")
          (produces 9999-12-31T23:59-00:00))
 
 (ion_1_1 "the seconds argument"
@@ -212,26 +212,23 @@
                (text " (:make_timestamp 1 2 3 4 5 null.decimal 7) ")
                "may not be a float"
                (text " (:make_timestamp 1 2 3 4 5 6e0 7) ")
-               "may not be an integer"
-               (text "(:make_timestamp 2024 2 3 4 5 6)")
                "may not be multiple values"
                (text " (:make_timestamp 1 2 3 4 5 (:: 6. 6.) 7) ")
                (signals "invalid argument"))
          (then "in binary"
-               (then "is a tagged value"
+               (each "may be a tagged decimal"
                      (binary "EF 07"
                              "55 01"
-                             "0F 27 0C 1F" // Y Y M D
-                             "17 3B"       // H m
+                             "62 0F 27 61 0C 61 1F" // Y Y M D
+                             "61 17 61 3B"             // H m
                              "70")
-                     (produces 9999-12-31T23:59:00-00:00))
-               (then "may not be a tagged integer"
+                     "may be a tagged integer"
                      (binary "EF 07"
                              "55 01"
-                             "0F 27 0C 1F" // Y Y M D
-                             "17 3B"       // H m
+                             "62 0F 27 61 0C 61 1F" // Y Y M D
+                             "61 17 61 3B"             // H m
                              "60")
-                     (signals "invalid argument")))
+                     (produces 9999-12-31T23:59:00-00:00)))
          (then "must be a positive value"
                (then (text "(:make_timestamp 2024 2 3 4 5 -0.1)")
                      (signals "invalid argument"))
@@ -270,33 +267,33 @@
                "may not be multiple values"
                (text "(:make_timestamp 1 2 3 4 5 6. (:: 7 7))")
                (signals "invalid argument"))
-         (then "is encoded in binary as an int16"
+         (then "is encoded in binary as a tagged value"
                (then (binary "EF 07 55 05"
-                             "0F 27 0C 1E 17 3B 70"    // Y Y M D H m s
-                             "00 00")
+                             "62 0F 27 61 0C 61 1E 61 17 61 3B 70"    // Y Y M D H m s
+                             "60")
                      (produces 9999-12-30T23:59:00Z))
                (then (binary "EF 07 55 05"
-                             "0F 27 0C 1E 17 3B 70"    // Y Y M D H m s
-                             "11 11")
+                             "62 0F 27 61 0C 61 1E 61 17 61 3B 70"    // Y Y M D H m s
+                             "61 FF")
                      (produces 9999-12-30T23:59:00-00:01))
                (then (binary "EF 07 55 05"
-                             "0F 27 0C 1E 17 3B 70"    // Y Y M D H m s
-                             "01 00")
+                             "62 0F 27 61 0C 61 1E 61 17 61 3B 70"    // Y Y M D H m s
+                             "61 01")
                      (produces 9999-12-30T23:59:00+00:01))
                (then (binary "EF 07 55 05"
-                             "0F 27 0C 1F 17 3B 70"    // Y Y M D H m s
-                             "61 FA")
+                             "62 0F 27 61 0C 61 1E 61 17 61 3B 70"    // Y Y M D H m s
+                             "62 61 FA")
                      (produces 9999-12-30T23:59:00-23:59))
                (then (binary "EF 07 55 05"
-                             "0F 27 0C 1F 17 3B 70"    // Y Y M D H m s
-                             "9F 05")
+                             "62 0F 27 61 0C 61 1E 61 17 61 3B 70"    // Y Y M D H m s
+                             "62 9F 05")
                      (produces 9999-12-30T23:59:00+23:59)))
          (then "must be greater than -1440"
                (then (text "(:make_timestamp 2024 2 3 4 5 (::) -1440)") (signals "invalid argument"))
                (then (text "(:make_timestamp 2024 2 3 4 5 (::) -1439)") (produces 2024-02-03T04:05-23:59)))
          (then "must be less than 1440"
-               (then (text "(:make_timestamp 2024 2 3 4 5 (::) 1439)") (produces 2024-02-03T04:05+23:59)))
-               (then (text "(:make_timestamp 2024 2 3 4 5 (::) 1440)") (signals "invalid argument"))
+               (then (text "(:make_timestamp 2024 2 3 4 5 (::) 1439)") (produces 2024-02-03T04:05+23:59))
+               (then (text "(:make_timestamp 2024 2 3 4 5 (::) 1440)") (signals "invalid argument")))
          (then "may not cause the year, in UTC, to be less than 0001"
                (text "(:make_timestamp 1 1 1 0 0 0. 1439)")
                (signals "year cannot be less than 1"))

--- a/conformance/system_macros/none.ion
+++ b/conformance/system_macros/none.ion
@@ -18,10 +18,10 @@
                (produces /*nothing*/)))
 
 (ion_1_1 "none signals an error when"
-         (each "passed any expression value"
+         (each "argument is any expression value"
                (text "(:none 0)")
-               "passed an empty expression group"
+               "argument is an empty expression group"
                (text "(:none (::))")
-               "passed an expression that produces nothing"
+               "argument is an expression that produces nothing"
                (text "(:none (:none))")
                (signals "unexpected argument")))

--- a/conformance/system_macros/sum.ion
+++ b/conformance/system_macros/sum.ion
@@ -45,7 +45,7 @@
          (each (text "(:sum -3 -5)") (text "(:sum -5 -3)") (produces -8))
          (each (text "(:sum -2  4)") (text "(:sum  4 -2)") (produces  2)))
 
-(ion_1_1 "arguments may not be"
+(ion_1_1 "sum arguments may not be"
          (each "less than two integers"
                (text "(:sum)")
                (text "(:sum 1)")


### PR DESCRIPTION
**Issue #, if available:**

#88

**Description of changes:**

* Fixes "truncade" -> "truncate"
* Updates `delta`, `make_decimal`, `make_timestamp`, and `make_field` test cases, based on https://github.com/amazon-ion/ion-docs/pull/368
* Slight improvements to test names for `sum` and `none`

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
