### PR TITLE
Restack Ion 1.1 macros and symbols to meet spec changes

### DIFF
--- a/conformance/system_macros/add_symbols.ion
+++ b/conformance/system_macros/add_symbols.ion
@@ -5,20 +5,20 @@
          (each "in text with an unqualified macro name"
                (text ''' (:add_symbols "") ''')
                "in text with an unqualified macro address"
-               (text ''' (:12 "") ''')
+               (text ''' (:20 "") ''')
                "in text with a qualified macro name"
                (text ''' (:$ion::add_symbols "") ''')
-               "in text with a qualified macro address 12"
-               (text ''' (:$ion::12 "") ''')
-               "in binary with a system macro address 12"
-               (binary "EF 0C 01 90")
+               "in text with a qualified macro address 20"
+               (text ''' (:$ion::20 "") ''')
+               "in binary with a system macro address 20"
+               (binary "EF 14 01 90")
                "in binary with a user macro address"
-               (binary "0C 01 90")
+               (binary "14 01 90")
                (then "and produces only system values"
                      (produces))
                (then "and affects the symbol table"
-                     (toplevel '#$1' '#$65' '#$66')
-                     (produces '$ion' 'make_field' ''))))
+                     (toplevel '#$1' '#$63' '#$64')
+                     (produces '$ion' 'use' ''))))
 
 (ion_1_1 "add_symbols can accept"
          (then "an empty expression group"
@@ -26,10 +26,10 @@
                (then "with no error and producing no user values"
                      (produces))
                (then "and does not remove any symbols"
-                     (toplevel '#$1' '#$65')
-                     (produces '$ion' 'make_field'))
+                     (toplevel '#$1' '#$63')
+                     (produces '$ion' 'use'))
                (then "and does not add any symbols"
-                     (toplevel '#$66')
+                     (toplevel '#$64')
                      (signals "invalid symbol id")))
          (each "a single string"
                (text "(:add_symbols '''a''')")
@@ -38,10 +38,10 @@
                (then "with no error and producing no user values"
                      (produces))
                (then "and does not remove any symbols"
-                     (toplevel '#$1' '#$65')
-                     (produces '$ion' 'make_field'))
+                     (toplevel '#$1' '#$63')
+                     (produces '$ion' 'use'))
                (then "and appends the new symbol to the symbol table"
-                     (toplevel '#$66')
+                     (toplevel '#$64')
                      (produces 'a')))
          (each "multiple strings"
                (text ''' (:add_symbols "a" "b" "c") ''')
@@ -52,10 +52,10 @@
                (then "with no error and producing no user values"
                      (produces))
                (then "and does not remove any symbols"
-                     (toplevel '#$1' '#$65')
-                     (produces '$ion' 'make_field'))
+                     (toplevel '#$1' '#$63')
+                     (produces '$ion' 'use'))
                (then "and appends the new symbols to the symbol table"
-                     (toplevel '#$66' '#$67' '#$68')
+                     (toplevel '#$64' '#$65' '#$66')
                      (produces 'a' 'b' 'c'))))
 
 (ion_1_1 "add_symbols does not accept"

--- a/conformance/system_macros/default.ion
+++ b/conformance/system_macros/default.ion
@@ -5,15 +5,15 @@
          (each "in text with an unqualified macro name"
                (text " (:default 0 1) ")
                "in text with an unqualified macro address"
-               (text " (:23 0 1) ")
+               (text " (:2 0 1) ")
                "in text with a qualified macro name"
                (text " (:$ion::default 0 1) ")
-               "in text using qualified system macro address 23"
-               (text " (:$ion::23 0 1) ")
-               "in binary using system macro address 23"
-               (binary "EF 17 05 60 61 01")
+               "in text using qualified system macro address 2"
+               (text " (:$ion::2 0 1) ")
+               "in binary using system macro address 2"
+               (binary "EF 02 05 60 61 01")
                "in binary with a user macro address"
-               (binary "17 05 60 61 01")
+               (binary "02 05 60 61 01")
                (produces 0)))
 
 (ion_1_1 "default produces"

--- a/conformance/system_macros/make_decimal.ion
+++ b/conformance/system_macros/make_decimal.ion
@@ -5,15 +5,15 @@
          (each "in text with an unqualified macro name"
                (text " (:make_decimal 0 0) ")
                "in text with an unqualified macro address"
-               (text " (:6 0 0) ")
+               (text " (:11 0 0) ")
                "in text with a qualified macro name"
                (text " (:$ion::make_decimal 0 0) ")
                "in text using qualified system macro address 6"
-               (text " (:$ion::6 0 0) ")
+               (text " (:$ion::11 0 0) ")
                "in binary using system macro address 6"
-               (binary "EF 06 01 01")
+               (binary "EF 0B 01 01")
                "in binary with a user macro address"
-               (binary "06 01 01")
+               (binary "0B 01 01")
                (produces 0.)))
 
 (ion_1_1 "the first argument must be a single, non-null integer"
@@ -35,11 +35,11 @@
                (signals "invalid argument")))
 
 (ion_1_1 "in binary both arguments are encoded as tagged values"
-         (then (binary "EF 06 60    60   ") (produces 0d0))
-         (then (binary "EF 06 61 01 61 01") (produces 1d1))
-         (then (binary "EF 06 61 FF 61 01") (produces -1d1))
-         (then (binary "EF 06 61 01 61 FF") (produces 1d-1))
-         (then (binary "EF 06 61 FF 61 FF") (produces -1d-1)))
+         (then (binary "EF 0B 60    60   ") (produces 0d0))
+         (then (binary "EF 0B 61 01 61 01") (produces 1d1))
+         (then (binary "EF 0B 61 FF 61 01") (produces -1d1))
+         (then (binary "EF 0B 61 01 61 FF") (produces 1d-1))
+         (then (binary "EF 0B 61 FF 61 FF") (produces -1d-1)))
 
 (ion_1_1 "make_decimal creates a single unannotated decimal"
          (then (text "(:make_decimal -3 1)") (produces -3d1))

--- a/conformance/system_macros/make_string.ion
+++ b/conformance/system_macros/make_string.ion
@@ -5,15 +5,15 @@
          (each "in text with an unqualified macro name"
                (text " (:make_string (::)) ")
                "in text with an unqualified macro address"
-               (text " (:3 (::)) ")
+               (text " (:9 (::)) ")
                "in text with a qualified macro name"
                (text " (:$ion::make_string (::)) ")
-               "in text using qualified system macro address 3"
-               (text " (:$ion::3 (::)) ")
-               "in binary using system macro address 3"
-               (binary "EF 03 00")
+               "in text using qualified system macro address 9"
+               (text " (:$ion::9 (::)) ")
+               "in binary using system macro address 9"
+               (binary "EF 09 00")
                "in binary with a user macro address"
-               (binary "03 00")
+               (binary "09 00")
                (produces "")))
 
 (ion_1_1 "make_string creates a single, unannotated string from"

--- a/conformance/system_macros/make_symbol.ion
+++ b/conformance/system_macros/make_symbol.ion
@@ -5,15 +5,15 @@
          (each "in text with an unqualified macro name"
                (text " (:make_symbol (::)) ")
                "in text with an unqualified macro address"
-               (text " (:4 (::)) ")
+               (text " (:10 (::)) ")
                "in text with a qualified macro name"
                (text " (:$ion::make_symbol (::)) ")
-               "in text using qualified system macro address 4"
-               (text " (:$ion::4 (::)) ")
-               "in binary using system macro address 4"
-               (binary "EF 04 00")
+               "in text using qualified system macro address 10"
+               (text " (:$ion::10 (::)) ")
+               "in binary using system macro address 10"
+               (binary "EF 0A 00")
                "in binary with a user macro address"
-               (binary "04 00")
+               (binary "0A 00")
                (produces '')))
 
 (ion_1_1 "make_symbol creates a single, unannotated symbol from"

--- a/conformance/system_macros/make_timestamp.ion
+++ b/conformance/system_macros/make_timestamp.ion
@@ -5,15 +5,15 @@
          (each "in text with an unqualified macro name"
                (text " (:make_timestamp 1) ")
                "in text with an unqualified macro address"
-               (text " (:7 1) ")
+               (text " (:12 1) ")
                "in text with a qualified macro name"
                (text " (:$ion::make_timestamp 1) ")
-               "in text using qualified system macro address 7"
-               (text " (:$ion::7 1) ")
-               "in binary using system macro address 7"
-               (binary "EF 07 00 00 61 01")
+               "in text using qualified system macro address 12"
+               (text " (:$ion::12 1) ")
+               "in binary using system macro address 12"
+               (binary "EF 0C 00 00 61 01")
                "in binary with a user macro address"
-               (binary "07 00 00 61 01")
+               (binary "0C 00 00 61 01")
                (produces 0001T)))
 
 (ion_1_1 "make_timestamp produces a single, unannotated timestamp"
@@ -51,7 +51,7 @@
                (text " (:make_timestamp (:: 1 1) 2 3 4 5 6. 7) ")
                (signals "invalid argument"))
          (then "is encoded in binary as a tagged value"
-               (binary "EF 07" // System macro invocation
+               (binary "EF 0C" // System macro invocation
                        "00 00" // Presence bitmap
                        /* Y */ "62 0F 27")
                (produces 9999T))
@@ -77,7 +77,7 @@
                (text " (:make_timestamp 1 (:: 2 2) 3 4 5 6. 7) ")
                (signals "invalid argument"))
          (then "is encoded in binary as a tagged value"
-               (binary "EF 07"
+               (binary "EF 0C"
                        "01 00"
                        "62 0F 27" // Y Y Y
                        "61 0C")
@@ -105,7 +105,7 @@
                (text " (:make_timestamp 1 2 (:: 3 3) 4 5 6. 7) ")
                (signals "invalid argument"))
          (then "is encoded in binary as a tagged value"
-               (binary "EF 07"
+               (binary "EF 0C"
                        "05 00"
                        "62 0F 27 61 0C" // Y Y Y M M
                        "61 1F")
@@ -199,7 +199,7 @@
 
 (ion_1_1 "the hour and minute arguments are encoded in binary as tagged values"
          // We can't test the hour and minute arguments separately for this case
-         (binary "EF 07"
+         (binary "EF 0C"
                  "55 00"
                  "62 0F 27 61 0C 61 1F" // Y Y Y M M D D
                  "61 17 61 3B")
@@ -217,13 +217,13 @@
                (signals "invalid argument"))
          (then "in binary"
                (each "may be a tagged decimal"
-                     (binary "EF 07"
+                     (binary "EF 0C"
                              "55 01"
                              "62 0F 27 61 0C 61 1F" // Y Y Y M M D D
                              "61 17 61 3B"             // H H m m
                              "70")
                      "may be a tagged integer"
-                     (binary "EF 07"
+                     (binary "EF 0C"
                              "55 01"
                              "62 0F 27 61 0C 61 1F" // Y Y Y M M D D
                              "61 17 61 3B"             // H H m m
@@ -268,23 +268,23 @@
                (text "(:make_timestamp 1 2 3 4 5 6. (:: 7 7))")
                (signals "invalid argument"))
          (then "is encoded in binary as a tagged value"
-               (then (binary "EF 07 55 05"
+               (then (binary "EF 0C 55 05"
                              "62 0F 27 61 0C 61 1E 61 17 61 3B 70"    // Y Y Y M M D D H H m m s
                              "60")
                      (produces 9999-12-30T23:59:00Z))
-               (then (binary "EF 07 55 05"
+               (then (binary "EF 0C 55 05"
                              "62 0F 27 61 0C 61 1E 61 17 61 3B 70"    // Y Y Y M M D D H H m m s
                              "61 FF")
                      (produces 9999-12-30T23:59:00-00:01))
-               (then (binary "EF 07 55 05"
+               (then (binary "EF 0C 55 05"
                              "62 0F 27 61 0C 61 1E 61 17 61 3B 70"    // Y Y Y M M D D H H m m s
                              "61 01")
                      (produces 9999-12-30T23:59:00+00:01))
-               (then (binary "EF 07 55 05"
+               (then (binary "EF 0C 55 05"
                              "62 0F 27 61 0C 61 1E 61 17 61 3B 70"    // Y Y Y M M D D H H m m s
                              "62 61 FA")
                      (produces 9999-12-30T23:59:00-23:59))
-               (then (binary "EF 07 55 05"
+               (then (binary "EF 0C 55 05"
                              "62 0F 27 61 0C 61 1E 61 17 61 3B 70"    // Y Y Y M M D D H H m m s
                              "62 9F 05")
                      (produces 9999-12-30T23:59:00+23:59)))

--- a/conformance/system_macros/set_macros.ion
+++ b/conformance/system_macros/set_macros.ion
@@ -8,15 +8,15 @@
          (each "in text with an unqualified macro name"
                (text "(:set_macros) ")
                "in text with an unqualified macro address"
-               (text "(:13)")
+               (text "(:21)")
                "in text with a qualified macro name"
                (text "(:$ion::set_macros)")
-               "in text with a qualified macro address 13"
-               (text "(:$ion::13)")
-               "in binary with a system macro address 13"
-               (binary "EF 0D 00")
+               "in text with a qualified macro address 21"
+               (text "(:$ion::21)")
+               "in binary with a system macro address 21"
+               (binary "EF 15 00")
                "in binary with a user macro address"
-               (binary "0D 00")
+               (binary "15 00")
                (produces)))
 
 (ion_1_1 "set_macros can be invoked with a single macro"

--- a/conformance/system_macros/set_symbols.ion
+++ b/conformance/system_macros/set_symbols.ion
@@ -5,15 +5,15 @@
          (each "in text with an unqualified macro name"
                (text ''' (:set_symbols "") ''')
                "in text with an unqualified macro address"
-               (text ''' (:11 "") ''')
+               (text ''' (:19 "") ''')
                "in text with a qualified macro name"
                (text ''' (:$ion::set_symbols "") ''')
-               "in text with a qualified macro address 11"
-               (text ''' (:$ion::11 "") ''')
-               "in binary with a system macro address 11"
-               (binary "EF 0B 01 90")
+               "in text with a qualified macro address 19"
+               (text ''' (:$ion::19 "") ''')
+               "in binary with a system macro address 19"
+               (binary "EF 13 01 90")
                "in binary with a user macro address"
-               (binary "0B 01 90")
+               (binary "13 01 90")
                (then "and produces only system values"
                      (produces))
                (then "and affects the symbol table"

--- a/conformance/system_macros/sum.ion
+++ b/conformance/system_macros/sum.ion
@@ -5,15 +5,15 @@
          (each "in text with an unqualified macro name"
                (text "(:sum 0 0)")
                "in text with an unqualified macro address"
-               (text "(:20 0 0)")
+               (text "(:7 0 0)")
                "in text with a qualified macro name"
                (text "(:$ion::sum 0 0)")
                "in text with a qualified macro address"
-               (text "(:$ion::20 0 0)")
+               (text "(:$ion::7 0 0)")
                "in binary with a system macro address"
-               (binary "EF 14 60 60")
+               (binary "EF 07 60 60")
                "in binary with a user macro address"
-               (binary "14 60 60")
+               (binary "07 60 60")
                (produces 0)))
 
 (ion_1_1 "sum produces a single, unannotated integer that is the sum of"


### PR DESCRIPTION
See also: 
- https://github.com/amazon-ion/ion-rust/pull/879
- https://github.com/amazon-ion/ion-java/pull/1013

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
