### PR TITLE
Fix up macro addresses and add coverage for more edge cases

### DIFF
--- a/conformance/system_macros/add_macros.ion
+++ b/conformance/system_macros/add_macros.ion
@@ -8,15 +8,15 @@
          (each "in text with an unqualified macro name"
                (text "(:add_macros) ")
                "in text with an unqualified macro address"
-               (text "(:14)")
+               (text "(:22)")
                "in text with a qualified macro name"
                (text "(:$ion::add_macros)")
                "in text with a qualified macro address 14"
-               (text "(:$ion::14)")
+               (text "(:$ion::22)")
                "in binary with a system macro address 14"
-               (binary "EF 0E 00")
+               (binary "EF 16 00")
                "in binary with a user macro address"
-               (binary "0E 00")
+               (binary "16 00")
                (produces)))
 
 (ion_1_1 "add_macros can add a macro to the macro table"

--- a/conformance/system_macros/flatten.ion
+++ b/conformance/system_macros/flatten.ion
@@ -16,31 +16,45 @@
                (binary "13 00")
                (produces /*nothing*/)))
 
-(ion_1_1 "flatten creates a flat sequence of values from"
-         (then "0 values"
+(ion_1_1 "flatten creates a flat sequence of values"
+         (then "from 0 values"
                (text "(:flatten)")
                (produces /*nothing*/))
-         (each "one list"
+         (each "from one list"
                (text "(:flatten [1, 2, 3])")
-               "multiple lists"
+               "from multiple lists"
                (text "(:flatten [1, 2] [3])")
                (text "(:flatten [1] [2] [3])")
                (text "(:flatten [] [1, 2, 3] [])")
                (text "(:flatten [] [1] [] [2] [] [3] [])")
-               "one sexp"
+               "from one sexp"
                (text "(:flatten (1 2 3))")
-               "multiple sexps"
+               "from multiple sexps"
                (text "(:flatten (1 2) (3))")
                (text "(:flatten (1) (2) (3))")
                (text "(:flatten () (1 2 3) ())")
                (text "(:flatten () (1) () (2) () (3) ())")
-               "a mix of lists and sexps"
+               "from a mix of lists and sexps"
                (text "(:flatten () [1] (2) [3])")
                (text "(:flatten (1) [2, 3] ())")
-               "annotated sequence values"
+               "from annotated sequence values"
                // Argument annotations are silently dropped.
                (text "(:flatten a::() b::[1] c::(2) d::[3])")
-               (produces 1 2 3)))
+               "from nested flatten invocations"
+               (text "(:flatten (:flatten) [1, 2, 3])")
+               (text "(:flatten [1, 2, 3] (:flatten))")
+               (text "(:flatten (:: (:flatten) [1, 2, 3]))")
+               (text "(:flatten (:: [1, 2, 3] (:flatten)))")
+               (text "(:flatten (:flatten [[1, 2, 3]]))")
+               (text "(:flatten (:flatten [[1]]) [2, 3])")
+               (text "(:flatten [1, 2] (:flatten [[3]]))")
+               (produces 1 2 3))
+         (then "and can be embedded in a list"
+               (text "[ (:flatten (1 2 3) ) ]")
+               (produces [1, 2, 3]))
+         (then "and can be embedded in a sexp"
+               (text "( (:flatten [1,2,3]) )")
+               (produces (1 2 3))) )
 
 (ion_1_1 "the argument cannot be"
          (each "null"

--- a/conformance/system_macros/make_field.ion
+++ b/conformance/system_macros/make_field.ion
@@ -5,15 +5,15 @@
          (each "in text with an unqualified macro name"
                (text " (:make_field foo 0) ")
                "in text with an unqualified macro address"
-               (text " (:22 foo 0) ")
+               (text " (:16 foo 0) ")
                "in text with a qualified macro name"
                (text " (:$ion::make_field foo 0) ")
                "in text using qualified system macro address 22"
-               (text " (:$ion::22 foo 0) ")
+               (text " (:$ion::16 foo 0) ")
                "in binary using system macro address 22"
-               (binary "EF 16 A3 66 6F 6F 60")
+               (binary "EF 10 A3 66 6F 6F 60")
                "in binary with a user macro address"
-               (binary "16 A3 66 6F 6F 60")
+               (binary "10 A3 66 6F 6F 60")
                (produces {foo: 0} )))
 
 (ion_1_1 "the first argument"

--- a/conformance/system_macros/make_list.ion
+++ b/conformance/system_macros/make_list.ion
@@ -5,15 +5,15 @@
          (each "in text with an unqualified macro name"
                (text " (:make_list (::)) ")
                "in text with an unqualified macro address"
-               (text " (:8 (::)) ")
+               (text " (:14 (::)) ")
                "in text with a qualified macro name"
                (text " (:$ion::make_list (::)) ")
                "in text using qualified system macro address 8"
-               (text " (:$ion::8 (::)) ")
+               (text " (:$ion::14 (::)) ")
                "in binary using system macro address 8"
-               (binary "EF 08 00")
+               (binary "EF 0E 00")
                "in binary with a user macro address"
-               (binary "08 00")
+               (binary "0E 00")
                (produces [])))
 
 (ion_1_1 "make_list creates a single, unannotated list from"
@@ -27,6 +27,22 @@
                (text "(:make_list [1] [2] [3])")
                (text "(:make_list [] [1, 2, 3] [])")
                (text "(:make_list [] [1] [] [2] [] [3] [])")
+               "other make_list invocations"
+               (text "(:make_list (:make_list) [1, 2, 3])")
+               (text "(:make_list [1, 2, 3] (:make_list))")
+               (text "(:make_list (:: (:make_list) [1, 2, 3]))")
+               (text "(:make_list (:: [1, 2, 3] (:make_list)))")
+               (text "(:make_list (:make_list [1]) (:make_list [2]) (:make_list [3]))")
+               (text "(:make_list (:make_list (:: [1])) (:make_list (:: [2])) (:make_list (:: [3])))")
+               (text "(:make_list (:: (:make_list [1]) (:make_list [2]) (:make_list [3])))")
+               (text "(:make_list (:: (:make_list (:: [1])) (:make_list (:: [2])) (:make_list (:: [3]))))")
+               (text "(:make_list (:make_list [1, 2, 3]))")
+               (text "(:make_list (:make_list (:make_list [1, 2, 3])))")
+               (text "(:make_list (:make_list (:make_list (:make_list [1, 2, 3]))))")
+               "tdl invocations"
+               (text "(:add_macros (macro foo (x) (.make_list (%x))))              (:foo [1, 2, 3])")
+               (text "(:add_macros (macro foo (x) (.make_list (%x))))              (:foo (:make_list [1, 2, 3]))")
+               (text "(:add_macros (macro bar (x) (.make_list (.make_list (%x))))) (:bar [1, 2, 3])")
                "one sexp"
                (text "(:make_list (1 2 3))")
                "multiple sexps"

--- a/conformance/system_macros/make_sexp.ion
+++ b/conformance/system_macros/make_sexp.ion
@@ -5,15 +5,15 @@
          (each "in text with an unqualified macro name"
                (text " (:make_sexp (::)) ")
                "in text with an unqualified macro address"
-               (text " (:9 (::)) ")
+               (text " (:15 (::)) ")
                "in text with a qualified macro name"
                (text " (:$ion::make_sexp (::)) ")
                "in text using qualified system macro address 9"
-               (text " (:$ion::9 (::)) ")
+               (text " (:$ion::15 (::)) ")
                "in binary using system macro address 9"
-               (binary "EF 09 00")
+               (binary "EF 0F 00")
                "in binary with a user macro address"
-               (binary "09 00")
+               (binary "0F 00")
                (produces ())))
 
 (ion_1_1 "make_sexp creates a single, unannotated sexp from"
@@ -37,6 +37,22 @@
                "a mix of lists and sexps"
                (text "(:make_sexp () [1] (2) [3])")
                (text "(:make_sexp (1) [2, 3] ())")
+               "other make_sexp invocations"
+               (text "(:make_sexp (:make_sexp) [1, 2, 3])")
+               (text "(:make_sexp [1, 2, 3] (:make_sexp))")
+               (text "(:make_sexp (:: (:make_sexp) [1, 2, 3]))")
+               (text "(:make_sexp (:: [1, 2, 3] (:make_sexp)))")
+               (text "(:make_sexp (:make_sexp [1]) (:make_sexp [2]) (:make_sexp [3]))")
+               (text "(:make_sexp (:make_sexp (:: [1])) (:make_sexp (:: [2])) (:make_sexp (:: [3])))")
+               (text "(:make_sexp (:: (:make_sexp [1]) (:make_sexp [2]) (:make_sexp [3])))")
+               (text "(:make_sexp (:: (:make_sexp (:: [1])) (:make_sexp (:: [2])) (:make_sexp (:: [3]))))")
+               (text "(:make_sexp (:make_sexp [1, 2, 3]))")
+               (text "(:make_sexp (:make_sexp (:make_sexp [1, 2, 3])))")
+               (text "(:make_sexp (:make_sexp (:make_sexp (:make_sexp [1, 2, 3]))))")
+               "tdl invocations"
+               (text "(:add_macros (macro foo (x) (.make_sexp (%x))))              (:foo [1, 2, 3])")
+               (text "(:add_macros (macro foo (x) (.make_sexp (%x))))              (:foo (:make_sexp [1, 2, 3]))")
+               (text "(:add_macros (macro bar (x) (.make_sexp (.make_sexp (%x))))) (:bar [1, 2, 3])")
                "annotated sequence values"
                // Argument annotations are silently dropped.
                (text "(:make_sexp a::() b::[1] c::(2) d::[3])")

--- a/conformance/system_macros/make_struct.ion
+++ b/conformance/system_macros/make_struct.ion
@@ -5,15 +5,15 @@
          (each "in text with an unqualified macro name"
                (text " (:make_struct (::)) ")
                "in text with an unqualified macro address"
-               (text " (:10 (::)) ")
+               (text " (:17 (::)) ")
                "in text with a qualified macro name"
                (text " (:$ion::make_struct (::)) ")
                "in text using qualified system macro address 10"
-               (text " (:$ion::10 (::)) ")
+               (text " (:$ion::17 (::)) ")
                "in binary using system macro address 10"
-               (binary "EF 0A 00")
+               (binary "EF 11 00")
                "in binary with a user macro address"
-               (binary "0A 00")
+               (binary "11 00")
                (produces {})))
 
 (ion_1_1 "make_struct creates a single, unannotated struct from"
@@ -26,11 +26,18 @@
          (each "one struct"
                (text "(:make_struct {a:1, b:2, c:3})")
                "multiple structs"
-               (text "(:make_struct {a:1, b:2} {b:3})")
-               (text "(:make_struct {} {a:1} {} {b:2} {} {b:3})")
+               (text "(:make_struct {a:1, b:2} {c:3})")
+               (text "(:make_struct {} {a:1} {} {b:2} {} {c:3})")
+               "other make_struct invocations"
+               (text "(:make_struct (:make_struct {a:1} {b:2} {c:3}))")
+               (text "(:make_struct (:make_struct {} {a:1} {} {b:2} {} {c:3}))")
+               "make_field invocations"
+               (text "(:make_struct (:make_field a 1) (:make_field b 2) (:make_field c 3))")
+               (text "(:make_struct (:: (:make_field a 1) (:make_field b 2) (:make_field c 3)))")
                "annotated struct values"
                // Argument annotations are silently dropped.
                (text "(:make_struct a::{} b::{a:1} c::{b:2} d::{c:3})")
+               (text "(:make_struct a::{a:1} b::{b:2} c::{c:3} d::{})")
                (produces {a:1, b:2, c:3}))
          (then "structs with repeated fields"
                (text "(:make_struct {a:1} {a:1})")

--- a/conformance/system_macros/repeat.ion
+++ b/conformance/system_macros/repeat.ion
@@ -5,15 +5,15 @@
          (each "in text with an unqualified macro name"
                (text ''' (:repeat 1 1) ''')
                "in text with an unqualified macro address"
-               (text ''' (:17 1 1) ''')
+               (text ''' (:4 1 1) ''')
                "in text with a qualified macro name"
                (text ''' (:$ion::repeat 1 1) ''')
                "in text with a qualified macro address"
-               (text ''' (:$ion::17 1 1) ''')
+               (text ''' (:$ion::4 1 1) ''')
                "in binary with a system macro address"
-               (binary "EF 11 01 61 01 61 01")
+               (binary "EF 04 01 61 01 61 01")
                "in binary with a user macro address"
-               (binary "11 01 61 01 61 01")
+               (binary "04 01 61 01 61 01")
                (produces 1)))
 
 (ion_1_1 "repeat can produce"


### PR DESCRIPTION
**Issue #, if available:**

#88

**Description of changes:**

* Fixes up the macro IDs for `add_macros`, `repeat` (don't know how those were missed), as well as `flatten`, `make_struct`, etc. (those tests are/were not being run because `ion-java` doesn't support those yet).
* Adds more test cases for `make_list`, `make_sexp`, `make_struct`, and `flatten`.


_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
