### PR TITLE
Add conformance tests for `for` and `literal` special forms

### DIFF
--- a/conformance/tdl/for.ion
+++ b/conformance/tdl/for.ion
@@ -1,19 +1,122 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-// * Test cases for `for`
-//   * binding names, keywords, etc. cannot be annotated
-//   * Can iterate one stream
-//   * Can iterate more than one stream
-//   * Can iterate empty stream
-//   * Can iterate non-empty stream
-//   * Can use grouping syntax for avoiding ambiguity
-//   * Creates a new binding for the stream iteration
-//     * Bindings can shadow the macro variables
-//     * Bindings can shadow an outer `for`
-//   * Iteration ends when the shorter stream is complete
-//     * When there's one stream
-//     * When there's multiple streams, and the first stream is shortest
-//     * When there's multiple streams, and the second (or later) is the shortest
-//     * When two streams have the same length
-//   * `for` should have exactly one template body expression
+(ion_1_1 "`for` can iterate over"
+         (each "an empty stream"
+               (mactab (macro foo () (.for (x) { a: (%x) })))
+               (mactab (macro foo () (.for (x (.none)) { a: (%x) })))
+               (mactab (macro foo () (.for [(x)] { a: (%x) })))
+               (mactab (macro foo () (.for ((x)) { a: (%x) })))
+               (then (text "1 (:foo) 2")
+                     (produces 1 2)))
+         (then "a stream of constant scalar values"
+               (mactab (macro foo () (.for (x 1 2 3) { a: (%x) })))
+               (text "1 (:foo) 2")
+               (produces 1 {a:1} {a:2} {a:3} 2 ))
+         (then "a variable with a stream of scalar values"
+               (mactab (macro foo (y*) (.for (x (%y)) { a: (%x) })))
+               (text "1 (:foo 1 2 3) 2")
+               (produces 1 {a:1} {a:2} {a:3} 2 ))
+         (then "a stream of constant container values"
+               (mactab (macro foo () (.for (x [] [1] [1, 2]) { a: (%x) })))
+               (text "1 (:foo) 2")
+               (produces 1 {a:[]} {a:[1]} {a:[1, 2]} 2 ))
+         (then "a variable with a stream of container values"
+               (mactab (macro foo (y*) (.for (x (%y)) { a: (%x) })))
+               (text "1 (:foo [] [1] [1, 2]) 2")
+               (produces 1 {a:[]} {a:[1]} {a:[1, 2]} 2 )))
+
+(ion_1_1 "a `for` clause can be nested in another `for` clause"
+         (mactab (macro foo () (.for (x 1 2 3) (.for (y 4 5 6) (%y)))))
+         (text "1 (:foo) 2")
+         (produces 1 4 5 6 4 5 6 4 5 6 2))
+
+(ion_1_1 "`for` variable bindings"
+         (then "can shadow macro variables"
+               (mactab (macro foo (x) (.for (x 1 2 3) { a: (%x) })))
+               (text "1 (:foo 99) 2")
+               (produces 1 {a:1} {a:2} {a:3} 2 ))
+         (then "can shadow an outer `for`'s bindings"
+               (mactab (macro foo () (.for (x a b c) (.for (x d e f) (%x)))) )
+               (text "1 (:foo) 2")
+               (produces 1 d e f d e f d e f 2))
+         (then "can reference outer bindings that they are shadowing"
+               (mactab (macro foo (x) (.for [(x 1 (%x) 3)] { a: (%x) })))
+               (text "1 (:foo 99) 2")
+               (produces 1 {a:1} {a:99} {a:3} 2 ))
+         (then "can reference outer bindings that are shadowed by another binding in that `for` clause"
+               (mactab (macro foo (x) (.for [(x 1 2 3), (y 4 (%x) 6)] { a: (%x), b: (%y) })))
+               (text "1 (:foo 99) 2")
+               (produces 1 {a:1,b:4} {a:2,b:99} {a:3,b:6} 2 ))
+         (each "must be present"
+               (mactab (macro foo () (.for [/* no variable binding clause here */] "body")))
+               "must not be an empty s-expression"
+               (mactab (macro foo () (.for () "body")))
+               (mactab (macro foo () (.for [(x 1 2 3), ()] "body")))
+               "must not have a null binding name"
+               (mactab (macro foo () (.for (null 1 2 3) (%y))))
+               (mactab (macro foo () (.for (null.symbol 1 2 3) (%y))))
+               "must not have an annotated binding name"
+               (mactab (macro foo () (.for (x::y 1 2 3) (%y))))
+               "must have a binding name that is a symbol"
+               (mactab (macro foo () (.for ("y" 1 2 3) (%y))))
+               "must not repeat binding names in the same `for` clause"
+               (mactab (macro foo () (.for [(x 1 2 3), (x 1 2 3)] (%x))))
+               "cannot bind to another variable declared in the same `for` clause"
+               (mactab (macro foo () (.for [(x 1 2 3), (y (%x))] (%y))))
+               (signals "invalid macro definition")))
+
+(ion_1_1 "the body expression can use variable bindings"
+         (then "from the macro signature"
+               (mactab (macro foo (x y*) (.for (z (%y)) { a: (%x), b: (%z) })))
+               (text "1 (:foo 0 (::1 2 3)) 2")
+               (produces 1 {a:0,b:1} {a:0,b:2} {a:0,b:3} 2 ))
+         (then "that were declared in any outer `for` clauses"
+               (mactab (macro foo () (.for (x a b c) (.for (y 1 2 3) (.make_field (%x) (%y))))))
+               (text "1 (:foo) 2")
+               (produces 1 {a:1} {a:2} {a:3} {b:1} {b:2} {b:3} {c:1} {c:2} {c:3} 2)))
+
+(ion_1_1 "`for` can iterate multiple streams in parallel"
+         (mactab (macro iter2 (x* y*) (.for [(xx (%x)), (yy (%y))] (%xx) ))
+                 (macro iter5 (a* b* c* d* e*)
+                        (.for ((aa (%a))
+                               (bb (%b))
+                               (cc (%c))
+                               (dd (%d))
+                               (ee (%e))) (%aa) )))
+         (then "and iteration ends when the shortest stream has no more elements"
+               (each "when all streams are empty"
+                     (text "(:iter2)")
+                     (text "(:iter5)")
+                     (produces))
+               (then "when any one stream is empty"
+                     (text "(:iter2 (::) (:: a b c) ))")
+                     (text "(:iter2 (:: 1 2 3) (::) ))")
+                     (text "(:iter5 (::) (::3 4) (::5 6) (::7 8) (::9 0) ))")
+                     (text "(:iter5 (::1 2) (::) (::5 6) (::7 8) (::9 0) ))")
+                     (text "(:iter5 (::1 2) (::3 4) (::) (::7 8) (::9 0) ))")
+                     (text "(:iter5 (::1 2) (::3 4) (::5 6) (::) (::9 0) ))")
+                     (text "(:iter5 (::1 2) (::3 4) (::5 6) (::7 8) (::) ))")
+                     (produces))
+               (then "when any one non-empty stream is the shortest"
+                     (text "(:iter2 (::1) (::a b c) ))")
+                     (text "(:iter2 (::1 2 3) (::a) ))")
+                     (text "(:iter5 (::1) (::3 4) (::5 6) (::7 8) (::9 0) ))")
+                     (text "(:iter5 (::1 2) (::3) (::5 6) (::7 8) (::9 0) ))")
+                     (text "(:iter5 (::1 2) (::3 4) (::5) (::7 8) (::9 0) ))")
+                     (text "(:iter5 (::1 2) (::3 4) (::5 6) (::7) (::9 0) ))")
+                     (text "(:iter5 (::1 2) (::3 4) (::5 6) (::7 8) (::9) ))")
+                     (produces 1))
+               (then "when all streams are equally long"
+                     (text "(:iter2 (::1 2) (::a b) ))")
+                     (text "(:iter5 (::1 2) (::3 4) (::5 6) (::7 8) (::9 0) ))")
+                     (produces 1 2))))
+
+(ion_1_1 "`for` should raise an error when"
+         (each "there are no arguments provided"
+               (mactab (macro foo () (.for)))
+               "there is no body clause"
+               (mactab (macro foo () (.for (x 1 2 3) /* Body would be here */)))
+               "there is more than one body clause"
+               (mactab (macro foo () (.for (x 1 2 3) (%x) (%x) )))
+               (signals "invalid macro definition")))

--- a/conformance/tdl/literal.ion
+++ b/conformance/tdl/literal.ion
@@ -1,17 +1,87 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-// TODO:
-//   - literal can wrap
-//     - each type of scalar value
-//     - the `literal` special form
-//     - variable-expansion-like syntax
-//       - things that would be invalid syntax, such as annotations on the `%` operator
-//     - macro-like syntax
-//       - both names and addresses
-//       - qualified and unqualified
-//       - things that would be invalid syntax, such as annotations on the `.` operator
-//     - expression-group-like syntax
-//       - things that would be invalid syntax, such as annotations on the `..` operator
-//   - literal does not prevent evaluation of e-expressions
-//   - literal does not prevent SIDs from being interpreted
+(ion_1_1 "the literal special form"
+         (then "can wrap a null value"
+               (mactab (macro foo () (.literal null)))
+               (toplevel ('#$:foo')) (produces null))
+         (then "can wrap a bool value"
+               (mactab (macro foo () (.literal true )))
+               (toplevel ('#$:foo')) (produces true ))
+         (then "can wrap an int value"
+               (mactab (macro foo () (.literal 123 )))
+               (toplevel ('#$:foo')) (produces 123 ))
+         (then "can wrap a float value"
+               (mactab (macro foo () (.literal 1.2e3 )))
+               (toplevel ('#$:foo')) (produces 1.2e3 ))
+         (then "can wrap a decimal value"
+               (mactab (macro foo () (.literal 1.23 )))
+               (toplevel ('#$:foo')) (produces 1.23 ))
+         (then "can wrap a timestamp value"
+               (mactab (macro foo () (.literal 2025T )))
+               (toplevel ('#$:foo')) (produces 2025T ))
+         (then "can wrap a string value"
+               (mactab (macro foo () (.literal "abc" )))
+               (toplevel ('#$:foo')) (produces "abc" ))
+         (then "can wrap a symbol value"
+               (mactab (macro foo () (.literal abc )))
+               (toplevel ('#$:foo')) (produces abc ))
+         (then "can wrap a blob value"
+               (mactab (macro foo () (.literal null.blob )))
+               (toplevel ('#$:foo')) (produces null.blob ))
+         (then "can wrap a clob value"
+               (mactab (macro foo () (.literal {{""}} )))
+               (toplevel ('#$:foo')) (produces {{""}} ))
+         (then "can wrap a list value"
+               (mactab (macro foo () (.literal [] )))
+               (toplevel ('#$:foo')) (produces [] ))
+         (then "can wrap a sexp value"
+               (mactab (macro foo () (.literal () )))
+               (toplevel ('#$:foo')) (produces ()))
+         (then "can wrap a struct value"
+               (mactab (macro foo () (.literal {} )))
+               (toplevel ('#$:foo')) (produces {} ))
+         (then "can wrap multiple expressions"
+               (mactab (macro foo () (.literal 1 2 3 )))
+               (toplevel ('#$:foo')) (produces 1 2 3 ))
+         (each "can wrap things that would be invalid tdl syntax"
+               (mactab (macro foo (x) (.literal (%))) )
+               (mactab (macro foo (x) (.literal /* unresolvable variable */ (%y))))
+               (mactab (macro foo (x) (.literal hi::(%x))) )
+               (mactab (macro foo (x) (.literal (hi::'%'))) )
+               (mactab (macro foo (x) (.literal (hi::'%'x))) )
+               (mactab (macro foo (x) (.literal (% hi::x))) )
+               (mactab (macro foo () (.literal (..))) )
+               (mactab (macro foo () (.literal (.values hi::(..)))) )
+               (mactab (macro foo () (.literal (.values (hi::'..')))) )
+               (mactab (macro foo () (.literal (.))) )
+               (mactab (macro foo () (.literal hi::(.values))) )
+               (mactab (macro foo () (.literal (hi::'.'values))) )
+               // NOTE: We add an application value here to ensure that the macro table must be evaluated by any reader.
+               (then (toplevel 1) (produces 1)))
+         (then "causes things that look like macro invocations by name to be evaluated as literal s-expressions"
+               (mactab (macro foo () (.literal (.values 1 2 3))))
+               (toplevel ('#$:foo')) (produces (.values 1 2 3)))
+         (then "causes things that look like macro invocations by address to be evaluated as literal s-expressions"
+               (mactab (macro foo () (.literal (.0))))
+               (toplevel ('#$:foo')) (produces (.0)))
+         (then "causes things that look like qualified macro invocations to be evaluated as literal s-expressions"
+               (mactab (macro foo () (.literal (.$ion::values 1 2 3))))
+               (toplevel ('#$:foo')) (produces (.$ion::values 1 2 3)))
+         (then "causes things that look like expression groups to be evaluated as literal s-expressions"
+               (mactab (macro foo () (.values (.literal (.. 1 2 3)))))
+               (toplevel ('#$:foo')) (produces (.. 1 2 3)))
+         (then "causes things that look like variable expansions to be evaluated as literal s-expressions"
+               (mactab (macro foo () (.literal (%x))))
+               (toplevel ('#$:foo')) (produces (%x)))
+         (then "causes things that look like a nested literal special form to be evaluated as a literal s-expressions"
+               (mactab (macro foo () (.literal (.literal 1))))
+               (toplevel ('#$:foo')) (produces (.literal 1)))
+         (then "does not prevent interpretation of symbol IDs"
+               (encoding (symbols "a"))
+               (mactab (macro foo () (.literal $1)))
+               (toplevel ('#$:foo')) (produces a))
+         (then "does not prevent evaluation of e-expressions"
+               (encoding (symbols "a"))
+               (text "(:add_macros (macro foo () (.literal (:values 1) )))")
+               (toplevel ('#$:foo')) (produces 1)))


### PR DESCRIPTION
**Issue #, if available:**

#88 

**Description of changes:**

Replaces the comments with real test cases for `for` and `literal` special forms.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
