### PR TITLE
Add test cases for variable expansion and 'use' system macro

### DIFF
--- a/conformance/system_macros/use.ion
+++ b/conformance/system_macros/use.ion
@@ -1,12 +1,99 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-// Test Cases:
-// `use` can be invoked using any type of macro reference.
-// the first parameter must have a single argument value that is a non-null, unannotated string
-// the second parameter may be absent or it may be a single value that is a non-null, unannotated, positive integer
-// if the second parameter is absent, it has an implicit default value of 1
-// if the <catalog_key, version> pair cannot be located, in the catalog, the reader should signal an error
-// invoking `use` should preserve all existing symbols and macros
-// invoking `use` should import the specified module and append its content to the default module's symbol table and macro table
-// `use` should not (re)define any existing stream-level module bindings
+(ion_1_1 "use can be invoked"
+         (each "in text with an unqualified macro name"
+               (text '''(:use "abcs" 1)''')
+               "in text with an unqualified macro address"
+               (text '''(:23 "abcs" 1)''')
+               "in text with a qualified macro name"
+               (text '''(:$ion::use "abcs" 1)''')
+               "in text with a qualified macro address"
+               (text '''(:$ion::23 "abcs" 1)''')
+               "in binary with a system macro address"
+               (binary "EF 17 01 94 61 62 63 73 61 01")
+               "in binary with a user macro address"
+               (binary "17 01 94 61 62 63 73 61 01")
+               (produces)))
+
+(ion_1_1 "use imports the specified module and appends its symbols and macros to the default module"
+         (toplevel ('#$:use' "abcs" 1))
+         (then (toplevel '#$1' '#$2' '#$63')
+               (produces a $ion use)) // Coincidentally, the last system symbol is 'use'
+         (then (toplevel '#$64')
+               (signals "invalid symbol id"))
+         (then "preserving all existing symbols"
+               (toplevel ('#$:use' "mnop" 1) )
+               (toplevel '#$1' '#$2' '#$3' '#$63')
+               (produces a m $ion use)))
+
+(ion_1_1 "use can be invoked without the version parameter, defaulting to version 1"
+         (each (toplevel ('#$:use' "abcs")
+                         '#1' '#$2')
+               (toplevel ('#$:use' "abcs" ('#$::'))
+                         '#1' '#$2')
+               (produces a $ion)))
+
+(ion_1_1 "use can import a version other than 1"
+         (toplevel ('#$:use' "abcs" 2)
+                   '#$1' '#$2' '#$3')
+         (produces a b $ion))
+
+(ion_1_1 "repeated invocations can repeatedly add the same module"
+         (toplevel ('#$:use' "abcs"))
+         (then "again"
+               (toplevel ('#$:use' "abcs"))
+               (then (toplevel '#$1' '#$2') (produces a a))
+               (then "and again"
+                     (toplevel ('#$:use' "abcs"))
+                     (then (toplevel '#$1' '#$2' '#$3') (produces a a a))
+                     (then "and again"
+                           (toplevel ('#$:use' "abcs"))
+                           (then (toplevel '#$1' '#$2' '#$3' '#$4') (produces a a a a))))))
+
+(ion_1_1 "use may not be invoked"
+         (each "from TDL"
+               (mactab (macro foo () (.use (..))))
+               "in a list"
+               (toplevel [('#$:use')])
+               "in a sexp"
+               (toplevel (('#$:use')))
+               "in a struct"
+               (toplevel { a: ('#$:use') })
+               "as an e-expression argument"
+               (toplevel ('#$:values' ('#$:use') ))
+               (signals "use may only be invoked where system values can occur")))
+
+(ion_1_1 "the first argument"
+         (each "must be a string"
+               (toplevel ('#$:use' abcs 1))
+               "must not be null"
+               (toplevel ('#$:use' null.string 1))
+               "must not be annotated"
+               (toplevel ('#$:use' foo::"abcs" 1))
+               "must not be empty group of strings"
+               (toplevel ('#$:use' ('#$::') 1))
+               "must not be multiple strings"
+               (toplevel ('#$:use' ('#$::' "abcs" "mnop") 1))
+               (signals "invalid macro argument")))
+
+(ion_1_1 "the second argument"
+         (each "must be an integer"
+               (toplevel ('#$:use' "abcs" 1d0))
+               (toplevel ('#$:use' "abcs" 1e0))
+               "must be positive"
+               (toplevel ('#$:use' "abcs" -1))
+               (toplevel ('#$:use' "abcs" 0))
+               "must not be null"
+               (toplevel ('#$:use' "abcs" null.int))
+               "must not be annotated"
+               (toplevel ('#$:use' "abcs" foo::1))
+               "must not be multiple ints"
+               (toplevel ('#$:use' "abcs" ('#$::' 1 2)))
+               (signals "invalid macro argument")))
+
+(ion_1_1 "if the exact (catalog_key, version) pair cannot be located in the catalog, the reader should signal an error"
+         (toplevel ('#$:use' "mnop" 2))
+         (signals "shared module not found in catalog"))
+
+// TODO: `use` should not (re)define any existing stream-level module bindings

--- a/conformance/system_macros/use.ion
+++ b/conformance/system_macros/use.ion
@@ -24,7 +24,7 @@
                (signals "invalid symbol id"))
          (then "preserving all existing symbols"
                (toplevel ('#$:use' "mnop" 1) )
-               (toplevel '#$1' '#$2' '#$3' '#$63')
+               (toplevel '#$1' '#$2' '#$3' '#$64')
                (produces a m $ion use)))
 
 (ion_1_1 "use can be invoked without the version parameter, defaulting to version 1"
@@ -39,7 +39,7 @@
                    '#$1' '#$2' '#$3')
          (produces a b $ion))
 
-(ion_1_1 "repeated invocations can repeatedly add the same module"
+(ion_1_1 "repeated invocations can repeatedly add the content from the same module"
          (toplevel ('#$:use' "abcs"))
          (then "again"
                (toplevel ('#$:use' "abcs"))

--- a/conformance/tdl/variable_expansion.ion
+++ b/conformance/tdl/variable_expansion.ion
@@ -31,70 +31,67 @@
                (signals "invalid macro definition")))
 
 // EVALUATION TEST CASES
+//
+// All of these test cases include a wrapper macro so that the variables are not passed in as part of an E-Expression.
+// This helps to isolate the variable expansion logic from the E-Expression parsing logic in these test cases.
 
 (ion_1_1 "when expanding"
          (then "a zero-or-one parameter"
                (mactab (macro foo (x?) (%x)))
                (then "with zero arguments"
-                     (toplevel ('#$:foo' ('#$::')))
+                     (mactab (macro bar () (.foo (..))) )
+                     (toplevel ('#$:bar'))
                      (produces))
                (then "with one argument"
-                     (toplevel ('#$:foo' ('#$::' 1)))
+                     (mactab (macro bar () (.foo 1)) )
+                     (toplevel ('#$:bar'))
                      (produces 1))
                (then "with more than one argument"
-                     (toplevel ('#$:foo' ('#$::' 1 2 3)))
+                     (mactab (macro bar () (.foo (.. 1 2 3))) )
+                     (toplevel ('#$:bar'))
                      (signals "too many arguments")))
          (then "an exactly-one parameter"
                (mactab (macro foo (x) (%x)))
                (then "with zero arguments"
-                     (toplevel ('#$:foo' ('#$::')))
+                     (mactab (macro bar () (.foo (..))) )
+                     (toplevel ('#$:bar'))
                      (signals "too few arguments"))
                (then "with one argument"
-                     (toplevel ('#$:foo' ('#$::' 1)))
+                     (mactab (macro bar () (.foo 1)) )
+                     (toplevel ('#$:bar'))
                      (produces 1))
                (then "with more than one argument"
-                     (toplevel ('#$:foo' ('#$::' 1 2 3)))
+                     (mactab (macro bar () (.foo (.. 1 2 3))) )
+                     (toplevel ('#$:bar'))
                      (signals "too many arguments")))
          (then "a one-or-more parameter"
                (mactab (macro foo (x+) (%x)))
                (then "with zero arguments"
-                     (toplevel ('#$:foo' ('#$::')))
+                     (mactab (macro bar () (.foo (..))) )
+                     (toplevel ('#$:bar'))
                      (signals "too few arguments"))
                (then "with one argument"
-                     (toplevel ('#$:foo' ('#$::' 1)))
+                     (mactab (macro bar () (.foo 1)) )
+                     (toplevel ('#$:bar'))
                      (produces 1))
                (then "with more than one argument"
-                     (toplevel ('#$:foo' ('#$::' 1 2 3)))
+                     (mactab (macro bar () (.foo (.. 1 2 3))) )
+                     (toplevel ('#$:bar'))
                      (produces 1 2 3)))
          (then "a zero-or-more parameter"
                (mactab (macro foo (x*) (%x)))
                (then "with zero arguments"
-                     (toplevel ('#$:foo' ('#$::')))
+                     (mactab (macro bar () (.foo (..))) )
+                     (toplevel ('#$:bar'))
                      (produces))
                (then "with one argument"
-                     (toplevel ('#$:foo' ('#$::' 1)))
+                     (mactab (macro bar () (.foo 1)) )
+                     (toplevel ('#$:bar'))
                      (produces 1))
                (then "with more than one argument"
-                     (toplevel ('#$:foo' ('#$::' 1 2 3)))
+                     (mactab (macro bar () (.foo (.. 1 2 3))) )
+                     (toplevel ('#$:bar'))
                      (produces 1 2 3))))
-
-(ion_1_1 "the argument arity should not be checked for a variable that is unused"
-         (then "not enough args for exactly-one"
-               (mactab (macro foo (x) 123))
-               (toplevel ('#$:foo'))
-               (produces 123))
-         (then "too many args for exactly-one"
-               (mactab (macro foo (x) 123))
-               (toplevel ('#$:foo' ('#$::' 4 5 6)))
-               (produces 123))
-         (then "not enough args for one-or-more"
-               (mactab (macro foo (x+) 123))
-               (toplevel ('#$:foo'))
-               (produces 123))
-         (then "too-many args for zero-or-one"
-               (mactab (macro foo (x?) 123))
-               (toplevel ('#$:foo' ('#$::' 4 5 6)))
-               (produces 123)))
 
 (ion_1_1 "A variable expansion"
          (then "can be used inside a list"
@@ -118,10 +115,3 @@
          (mactab (macro foo (x) [(%x), (%x)]))
          (toplevel ('#$:foo' 1))
          (produces [1, 1]))
-
-(ion_1_1 "a variable should not be expanded if it is not being used"
-         // `x` should not be expanded. If it is expanded, the `(.none 123)` will signal an error.
-         (mactab (macro foo (x y) (%y))
-                 (macro bar (z) (.foo (.none 123) (%z))))
-         (toplevel ('#$:bar' 1))
-         (produces 1))

--- a/conformance/tdl/variable_expansion.ion
+++ b/conformance/tdl/variable_expansion.ion
@@ -45,7 +45,7 @@
                      (toplevel ('#$:foo' ('#$::' 1 2 3)))
                      (signals "too many arguments")))
          (then "an exactly-one parameter"
-               (mactab (macro foo (x?) (%x)))
+               (mactab (macro foo (x) (%x)))
                (then "with zero arguments"
                      (toplevel ('#$:foo' ('#$::')))
                      (signals "too few arguments"))
@@ -78,7 +78,7 @@
                      (toplevel ('#$:foo' ('#$::' 1 2 3)))
                      (produces 1 2 3))))
 
-(ion_1_1 "the argument arity should not be checked for a variable that unused"
+(ion_1_1 "the argument arity should not be checked for a variable that is unused"
          (then "not enough args for exactly-one"
                (mactab (macro foo (x) 123))
                (toplevel ('#$:foo'))

--- a/conformance/tdl/variable_expansion.ion
+++ b/conformance/tdl/variable_expansion.ion
@@ -3,15 +3,125 @@
 
 // DECLARATION TEST CASES
 
-// May not have annotations on the `%`, enclosing sexp, or variable name
-// May not have other values inside the enclosing sexp
-// Variable name must be a symbol and correspond to a valid, in-scope variable
+(ion_1_1 "a variable expansion"
+         (then "is denoted by (% <name> )"
+               (mactab (macro foo (x) (%x)))
+               // Check that this is valid syntax, and nothing else.
+               (produces /* nothing */))
+         (each "must not be annotated on the enclosing sexp"
+               (mactab (macro foo (x) a::(%x)))
+               "must not be annotated on the %"
+               (mactab (macro foo (x) (a::'%' x)))
+               "must not be annotated on the variable name"
+               (mactab (macro foo (x) (% a::x)))
+               "must use a symbol for the variable name"
+               (mactab (macro foo (x) (% "x")))
+               "must not have any extra expressions after the variable name"
+               (mactab (macro foo (x) (% x x)))
+               (mactab (macro foo (x) (% x null)))
+               (mactab (macro foo (x) (% x %)))
+               (mactab (macro foo (x) (% x ?)))
+               (mactab (macro foo (x) (% x +)))
+               (mactab (macro foo (x) (% x *)))
+               "must correspond to a valid, in-scope variable binding"
+               (mactab (macro foo (x) (%y)))
+               // `foo` cannot access `y` from where it is invoked in `bar`
+               (mactab (macro foo (x) (%y))
+                       (macro bar (y) (.foo 1)))
+               (signals "invalid macro definition")))
 
-// EVALUATION TEST CASES (Many of these tests should also be repeated for e-expression invocations)
+// EVALUATION TEST CASES
 
-// Cardinality checks for zero-or-one
-// Cardinality checks for exactly-one
-// Cardinality checks for zero-or-more
-// Cardinality checks for one-or-more
-// The variable cardinality should not be checked if the variable is unused.
-// A variable should not be expanded unless it is actually being used.
+(ion_1_1 "when expanding"
+         (then "a zero-or-one parameter"
+               (mactab (macro foo (x?) (%x)))
+               (then "with zero arguments"
+                     (toplevel ('#$:foo' ('#$::')))
+                     (produces))
+               (then "with one argument"
+                     (toplevel ('#$:foo' ('#$::' 1)))
+                     (produces 1))
+               (then "with more than one argument"
+                     (toplevel ('#$:foo' ('#$::' 1 2 3)))
+                     (signals "too many arguments")))
+         (then "an exactly-one parameter"
+               (mactab (macro foo (x?) (%x)))
+               (then "with zero arguments"
+                     (toplevel ('#$:foo' ('#$::')))
+                     (signals "too few arguments"))
+               (then "with one argument"
+                     (toplevel ('#$:foo' ('#$::' 1)))
+                     (produces 1))
+               (then "with more than one argument"
+                     (toplevel ('#$:foo' ('#$::' 1 2 3)))
+                     (signals "too many arguments")))
+         (then "a one-or-more parameter"
+               (mactab (macro foo (x+) (%x)))
+               (then "with zero arguments"
+                     (toplevel ('#$:foo' ('#$::')))
+                     (signals "too few arguments"))
+               (then "with one argument"
+                     (toplevel ('#$:foo' ('#$::' 1)))
+                     (produces 1))
+               (then "with more than one argument"
+                     (toplevel ('#$:foo' ('#$::' 1 2 3)))
+                     (produces 1 2 3)))
+         (then "a zero-or-more parameter"
+               (mactab (macro foo (x*) (%x)))
+               (then "with zero arguments"
+                     (toplevel ('#$:foo' ('#$::')))
+                     (produces))
+               (then "with one argument"
+                     (toplevel ('#$:foo' ('#$::' 1)))
+                     (produces 1))
+               (then "with more than one argument"
+                     (toplevel ('#$:foo' ('#$::' 1 2 3)))
+                     (produces 1 2 3))))
+
+(ion_1_1 "the argument arity should not be checked for a variable that unused"
+         (then "not enough args for exactly-one"
+               (mactab (macro foo (x) 123))
+               (toplevel ('#$:foo'))
+               (produces 123))
+         (then "too many args for exactly-one"
+               (mactab (macro foo (x) 123))
+               (toplevel ('#$:foo' ('#$::' 4 5 6)))
+               (produces 123))
+         (then "not enough args for one-or-more"
+               (mactab (macro foo (x+) 123))
+               (toplevel ('#$:foo'))
+               (produces 123))
+         (then "too-many args for zero-or-one"
+               (mactab (macro foo (x?) 123))
+               (toplevel ('#$:foo' ('#$::' 4 5 6)))
+               (produces 123)))
+
+(ion_1_1 "A variable expansion"
+         (then "can be used inside a list"
+               (mactab (macro foo (x) [(%x)] ) )
+               (toplevel ('#$:foo' 1))
+               (produces [1] ))
+         (then "can be used inside a sexp"
+               (mactab (macro foo (x) ((%x)) ) )
+               (toplevel ('#$:foo' 1))
+               (produces (1) ))
+         (then "can be used inside a struct"
+               (mactab (macro foo (x) {a:(%x)} ) )
+               (toplevel ('#$:foo' 1))
+               (produces {a:1} ))
+         (then "can be used inside deeply nested containers"
+               (mactab (macro foo (x) [(({a:[[(%x)]]}))] ))
+               (toplevel ('#$:foo' 1))
+               (produces [(({a:[[1]]}))] )))
+
+(ion_1_1 "a single parameter can be used in more than one variable expansion"
+         (mactab (macro foo (x) [(%x), (%x)]))
+         (toplevel ('#$:foo' 1))
+         (produces [1, 1]))
+
+(ion_1_1 "a variable should not be expanded if it is not being used"
+         // `x` should not be expanded. If it is expanded, the `(.none 123)` will signal an error.
+         (mactab (macro foo (x y) (%y))
+                 (macro bar (z) (.foo (.none 123) (%z))))
+         (toplevel ('#$:bar' 1))
+         (produces 1))


### PR DESCRIPTION
*Issue #, if available:*

#88 

*Description of changes:*

Adds test cases for `use` system macro, and TDL variable expansions.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
